### PR TITLE
refactor(botsdal): migrate GetBotChat/GetPlatformUser onto dal.GetRecordWithIDIntoData

### DIFF
--- a/DALGO-TYPED-COLLECTION.md
+++ b/DALGO-TYPED-COLLECTION.md
@@ -1,7 +1,16 @@
 # dalgo typed `Collection[K, T]` — applicability to bots-fw
 
-**Status:** investigated; **not adopted** (yet). dalgo upgraded to `v0.59.1` only.
+**Status:** **partially adopted.** dalgo `v0.61.0` added the factory accessor
+`dal.GetRecordWithIDIntoData`; `GetBotChat` and `GetPlatformUser` are now migrated
+onto it. Writes (`CreatePlatformUserRecord`) and struct/composite ids remain
+future work.
 **Date:** 2026-06-10
+
+> **Update (v0.61.0):** the dalgo-side unlock landed as
+> `dal.GetRecordWithIDIntoData[K, D](ctx, s, key, id, data)` — it decodes into a
+> caller-supplied value, so interface `D` (e.g. `BotChatData`) works. The reads
+> below are migrated; the design analysis is retained for context and for the
+> still-open items.
 
 ## TL;DR
 
@@ -151,18 +160,19 @@ Even with (A), `botsdal` would benefit from:
 - Removing the large commented-out blocks in `app_user_store.go`,
   `dal_bot_user.go`, `facade_user.go` first, so the refactor target is clear.
 
-## Recommendation
+## Recommendation / status
 
-1. **Now:** keep dalgo on `v0.59.1` (done). Do **not** force-fit `Collection[K,
-   T]` into the interface-generic `botsdal` — it would add churn and a worse
-   return type for no gain.
-2. **Next (dalgo):** add `record.GetDataWithID` (concrete) and
-   `record.ReadDataWithID` (caller-supplied/interface data). The latter is the
-   real unlock for frameworks like bots-fw and is low-risk (a thin, additive,
-   cycle-free helper).
-3. **Later (bots-fw):** once (2) lands, migrate `GetBotChat` / `GetPlatformUser`
-   / `CreatePlatformUserRecord` onto the typed helpers, after the commented-code
-   cleanup in §B.
-
-Adoption is feasible — it is gated on dalgo growing `DataWithID`-shaped accessors
-(or bots-fw going concrete/generic), not on anything fundamental.
+1. ~~**Next (dalgo):** add a caller-supplied/interface-data accessor.~~ **Done in
+   dalgo `v0.61.0`** as `dal.GetRecordWithIDIntoData` (the type
+   `record.ReadDataWithID` was renamed during review to `GetRecordWithIDIntoData`,
+   and `record.DataWithID` is now an alias for `dal.RecordWithDataAndID`).
+2. ~~**Later (bots-fw):** migrate `GetBotChat` / `GetPlatformUser`.~~ **Done** —
+   both now delegate to `dal.GetRecordWithIDIntoData(ctx, tx, key, id, data)`,
+   returning the same `record.DataWithID[string, D]` shape as before (it is now an
+   alias of `dal.RecordWithDataAndID`).
+3. **Still open:**
+   - `CreatePlatformUserRecord` is a write (`Insert`), not a read, so it stays on
+     `record.NewDataWithID` + `tx.Insert` — `GetRecordWithIDIntoData` is read-only.
+   - struct/composite ids in the typed `id K` slot remain deferred in dalgo.
+   - the large commented-out blocks in `app_user_store.go` / `dal_bot_user.go` /
+     `facade_user.go` are still candidates for cleanup.

--- a/botsdal/dal_bot_chat.go
+++ b/botsdal/dal_bot_chat.go
@@ -24,7 +24,5 @@ func GetBotChat(
 	newData func() botsfwmodels.BotChatData,
 ) (chat record.DataWithID[string, botsfwmodels.BotChatData], err error) {
 	key := NewBotChatKey(platformID, botID, chatID)
-	data := newData()
-	chat = record.NewDataWithID(chatID, key, data)
-	return chat, tx.Get(ctx, chat.Record)
+	return dal.GetRecordWithIDIntoData(ctx, tx, key, chatID, newData())
 }

--- a/botsdal/dal_bot_user.go
+++ b/botsdal/dal_bot_user.go
@@ -27,8 +27,8 @@ func GetPlatformUser(
 	platformUserData botsfwmodels.PlatformUserData,
 ) (botUser BotUser, err error) {
 	botUserKey := NewPlatformUserKey(platformID, botUserID)
-	botUser = BotUser(record.NewDataWithID(botUserID, botUserKey, platformUserData))
-	return botUser, tx.Get(ctx, botUser.Record)
+	dataWithID, err := dal.GetRecordWithIDIntoData(ctx, tx, botUserKey, botUserID, platformUserData)
+	return BotUser(dataWithID), err
 }
 
 // CreatePlatformUserRecord creates bot user record in database

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ go 1.24.3
 require (
 	github.com/bots-go-framework/bots-fw-store v0.10.3
 	github.com/bots-go-framework/bots-go-core v0.2.4
-	github.com/dal-go/dalgo v0.60.1
+	github.com/dal-go/dalgo v0.61.0
 	github.com/stretchr/testify v1.11.1
 	github.com/strongo/analytics v0.2.5
 	github.com/strongo/i18n v0.8.10

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,8 @@ github.com/bots-go-framework/bots-fw-store v0.10.3 h1:nGw1puS+wzI5XAnNyUBFerbaqx
 github.com/bots-go-framework/bots-fw-store v0.10.3/go.mod h1:s5L7PAMhdpf+zqkewV5m4uQKm/oVtv4QNyhdkSmNJwE=
 github.com/bots-go-framework/bots-go-core v0.2.4 h1:ppsw1MohTCFIDjp5tmccAokRAeq2PcuhNQooxsN4fFc=
 github.com/bots-go-framework/bots-go-core v0.2.4/go.mod h1:XCn9z4TI8sbgwyus+VDzw7iMY2QCPWEAvl23GMDjeEU=
-github.com/dal-go/dalgo v0.59.1 h1:RchGS5iq0+ob+PXjxYx928Cg33aE1N5t56koW3My+c8=
-github.com/dal-go/dalgo v0.59.1/go.mod h1:20tJJx7yt8qI8CZhUv1E/Q0HbIDRZXLVBU3JMzDpdvU=
-github.com/dal-go/dalgo v0.60.1 h1:eoKxwvKM3ws8SKndDVEPAfsB1ZBoIjUpK6X8q5NC4/w=
-github.com/dal-go/dalgo v0.60.1/go.mod h1:20tJJx7yt8qI8CZhUv1E/Q0HbIDRZXLVBU3JMzDpdvU=
+github.com/dal-go/dalgo v0.61.0 h1:cWixc48N+3jLlD0A2MNxg7fQvKrn+w2wJeuZAclNUE0=
+github.com/dal-go/dalgo v0.61.0/go.mod h1:20tJJx7yt8qI8CZhUv1E/Q0HbIDRZXLVBU3JMzDpdvU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=


### PR DESCRIPTION
## What
Migrates the two read accessors in `botsdal` onto dalgo's new factory accessor, and bumps **dalgo `v0.60.1 → v0.61.0`** (which ships it).

- `GetBotChat` → `dal.GetRecordWithIDIntoData(ctx, tx, key, chatID, newData())`
- `GetPlatformUser` → `BotUser(dal.GetRecordWithIDIntoData(ctx, tx, key, botUserID, platformUserData))`

`dal.GetRecordWithIDIntoData[K, D]` decodes the record **into the caller-supplied data value**, so the interface-typed models (`BotChatData`/`PlatformUserData`) + factory pattern work — exactly the case the convenience layer couldn't serve before. It returns `dal.RecordWithDataAndID[K, D]`, which (since dalgo #75) is what `record.DataWithID[K, D]` aliases — so the function return types are **unchanged**.

## Behavior preserved
Same `DataWithID` return shape, same not-found semantics, same data validation (`GetRecordWithIDIntoData` calls `NewRecordWithDataAndID` internally — the same validation the old `record.NewDataWithID` did). Pure refactor.

## Out of scope
- `CreatePlatformUserRecord` is a write (`Insert`), not a read — left as-is.
- struct/composite ids still deferred in dalgo.

Updates `DALGO-TYPED-COLLECTION.md` status to reflect the migration.

## Verification
- ✅ `go build`/`vet` clean · `golangci-lint` 0 issues · all tests pass (pre-commit hook + manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)