### PR TITLE
refactor(botsdal): migrate CreatePlatformUserRecord onto dal.InsertRecordWithDataAndID

### DIFF
--- a/DALGO-TYPED-COLLECTION.md
+++ b/DALGO-TYPED-COLLECTION.md
@@ -1,9 +1,10 @@
 # dalgo typed `Collection[K, T]` — applicability to bots-fw
 
-**Status:** **partially adopted.** dalgo `v0.61.0` added the factory accessor
-`dal.GetRecordWithIDIntoData`; `GetBotChat` and `GetPlatformUser` are now migrated
-onto it. Writes (`CreatePlatformUserRecord`) and struct/composite ids remain
-future work.
+**Status:** **adopted for point CRUD.** dalgo `v0.61.0` added the read accessor
+`dal.GetRecordWithIDIntoData` and `v0.62.0` the write twin
+`dal.InsertRecordWithDataAndID`; `GetBotChat`, `GetPlatformUser`, and
+`CreatePlatformUserRecord` are all migrated onto them. Struct/composite ids
+remain future work.
 **Date:** 2026-06-10
 
 > **Update (v0.61.0):** the dalgo-side unlock landed as
@@ -170,9 +171,10 @@ Even with (A), `botsdal` would benefit from:
    both now delegate to `dal.GetRecordWithIDIntoData(ctx, tx, key, id, data)`,
    returning the same `record.DataWithID[string, D]` shape as before (it is now an
    alias of `dal.RecordWithDataAndID`).
-3. **Still open:**
-   - `CreatePlatformUserRecord` is a write (`Insert`), not a read, so it stays on
-     `record.NewDataWithID` + `tx.Insert` — `GetRecordWithIDIntoData` is read-only.
+3. ~~`CreatePlatformUserRecord` write migration.~~ **Done** — dalgo `v0.62.0`
+   added the write twin `dal.InsertRecordWithDataAndID`, and
+   `CreatePlatformUserRecord` now delegates to it.
+4. **Still open:**
    - struct/composite ids in the typed `id K` slot remain deferred in dalgo.
    - the large commented-out blocks in `app_user_store.go` / `dal_bot_user.go` /
      `facade_user.go` are still candidates for cleanup.

--- a/botsdal/dal_bot_user.go
+++ b/botsdal/dal_bot_user.go
@@ -5,7 +5,6 @@ import (
 	"github.com/bots-go-framework/bots-fw-store/botsfwmodels"
 	"github.com/bots-go-framework/bots-fw/botsfwconst"
 	"github.com/dal-go/dalgo/dal"
-	"github.com/dal-go/dalgo/record"
 )
 
 const botUsersCollection = "botUsers"
@@ -44,8 +43,7 @@ func CreatePlatformUserRecord(
 		}
 	}
 	key := NewPlatformUserKey(platformID, botUserID)
-	platformUser := record.NewDataWithID(botUserID, key, platformUserData)
-	err = tx.Insert(ctx, platformUser.Record)
+	_, err = dal.InsertRecordWithDataAndID(ctx, tx, key, botUserID, platformUserData)
 	return err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ go 1.24.3
 require (
 	github.com/bots-go-framework/bots-fw-store v0.10.3
 	github.com/bots-go-framework/bots-go-core v0.2.4
-	github.com/dal-go/dalgo v0.61.0
+	github.com/dal-go/dalgo v0.62.0
 	github.com/stretchr/testify v1.11.1
 	github.com/strongo/analytics v0.2.5
 	github.com/strongo/i18n v0.8.10

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/bots-go-framework/bots-fw-store v0.10.3 h1:nGw1puS+wzI5XAnNyUBFerbaqx
 github.com/bots-go-framework/bots-fw-store v0.10.3/go.mod h1:s5L7PAMhdpf+zqkewV5m4uQKm/oVtv4QNyhdkSmNJwE=
 github.com/bots-go-framework/bots-go-core v0.2.4 h1:ppsw1MohTCFIDjp5tmccAokRAeq2PcuhNQooxsN4fFc=
 github.com/bots-go-framework/bots-go-core v0.2.4/go.mod h1:XCn9z4TI8sbgwyus+VDzw7iMY2QCPWEAvl23GMDjeEU=
-github.com/dal-go/dalgo v0.61.0 h1:cWixc48N+3jLlD0A2MNxg7fQvKrn+w2wJeuZAclNUE0=
-github.com/dal-go/dalgo v0.61.0/go.mod h1:20tJJx7yt8qI8CZhUv1E/Q0HbIDRZXLVBU3JMzDpdvU=
+github.com/dal-go/dalgo v0.62.0 h1:+ZvsV/y9QRZFpIAtm4XL6TwmR24MzQPcRxwV/qZ7g18=
+github.com/dal-go/dalgo v0.62.0/go.mod h1:20tJJx7yt8qI8CZhUv1E/Q0HbIDRZXLVBU3JMzDpdvU=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=


### PR DESCRIPTION
## What
Completes the typed-layer adoption for point CRUD. Migrates the write path onto dalgo's new write helper and bumps **dalgo `v0.61.0 → v0.62.0`**.

```go
// before: key := …; pu := record.NewDataWithID(id, key, data); err = tx.Insert(ctx, pu.Record)
// after:
key := NewPlatformUserKey(platformID, botUserID)
_, err = dal.InsertRecordWithDataAndID(ctx, tx, key, botUserID, platformUserData)
```

`dal.InsertRecordWithDataAndID` (the write twin of `GetRecordWithIDIntoData`) inserts the **caller-supplied `data` value as-is**, so the interface-typed `PlatformUserData` + factory works. Also drops the now-unused `record` import from `dal_bot_user.go`.

## Behavior preserved
The `Validate()` pre-check is unchanged; record construction/validation is identical (`InsertRecordWithDataAndID` builds via `NewRecordWithDataAndID`, exactly as the old `record.NewDataWithID` did). Pure refactor.

## Verification
- ✅ `go build`/`vet` clean · `golangci-lint` 0 issues · all tests pass (pre-commit hook + manual)

Updates `DALGO-TYPED-COLLECTION.md` → "adopted for point CRUD" (only struct/composite ids remain future work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)