### PR TITLE
fix(botsdal): remove truncated Deprecated comment on GetBotChat

### DIFF
--- a/botsdal/dal_bot_chat.go
+++ b/botsdal/dal_bot_chat.go
@@ -16,7 +16,6 @@ func NewBotChatKey(platformID botsfwconst.Platform, botID, chatID string) *dal.K
 }
 
 // GetBotChat returns bot chat
-// Deprecated: use
 func GetBotChat(
 	ctx context.Context,
 	tx dal.ReadSession,


### PR DESCRIPTION
## What
Removes the truncated `// Deprecated: use` line above `GetBotChat` — an abandoned edit with no replacement target.

## Why remove (not complete) it
- `GetBotChat` is **still the canonical accessor** (used by `webhook_context_base.go`).
- There's **no replacement function** to point a deprecation at.
- Its sibling `GetPlatformUser` is **not** deprecated, so deprecating only `GetBotChat` would be inconsistent.

One-line doc-comment change; no behavior change. Build/vet/tests/`golangci-lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)