### PR TITLE
test: cover botinput and botmsg packages (0% → 100%)

### DIFF
--- a/botinput/type_test.go
+++ b/botinput/type_test.go
@@ -1,0 +1,25 @@
+package botinput_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bots-go-framework/bots-fw/botinput"
+)
+
+func TestType_String(t *testing.T) {
+	// In-range value resolves to its generated name.
+	if got := botinput.TypeText.String(); got != "TypeText" {
+		t.Errorf("TypeText.String() = %q, want %q", got, "TypeText")
+	}
+	// Out-of-range value falls back to the numeric form.
+	if got := botinput.Type(-1).String(); !strings.HasPrefix(got, "Type(") {
+		t.Errorf("Type(-1).String() = %q, want a Type(n) fallback", got)
+	}
+}
+
+func TestGetBotInputTypeIdNameString(t *testing.T) {
+	if got := botinput.GetBotInputTypeIdNameString(botinput.TypeText); got != "2:TypeText" {
+		t.Errorf("GetBotInputTypeIdNameString(TypeText) = %q, want %q", got, "2:TypeText")
+	}
+}

--- a/botmsg/botmsg_test.go
+++ b/botmsg/botmsg_test.go
@@ -1,0 +1,60 @@
+package botmsg_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bots-go-framework/bots-fw/botmsg"
+)
+
+func TestAnswerCallbackQuery_BotMessageType(t *testing.T) {
+	if got := (botmsg.AnswerCallbackQuery{}).BotMessageType(); got != botmsg.TypeCallbackAnswer {
+		t.Errorf("BotMessageType() = %v, want %v", got, botmsg.TypeCallbackAnswer)
+	}
+}
+
+func TestAnswerCallbackQuery_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   botmsg.AnswerCallbackQuery
+		wantErr bool
+	}{
+		{name: "valid_minimal", query: botmsg.AnswerCallbackQuery{CallbackQueryID: "q1"}},
+		{name: "valid_full", query: botmsg.AnswerCallbackQuery{CallbackQueryID: "q1", Text: "ok", CacheTime: 5, URL: "https://t.me/bot?start=x"}},
+		{name: "empty_id", query: botmsg.AnswerCallbackQuery{}, wantErr: true},
+		{name: "text_too_long", query: botmsg.AnswerCallbackQuery{CallbackQueryID: "q1", Text: strings.Repeat("x", 201)}, wantErr: true},
+		{name: "negative_cache_time", query: botmsg.AnswerCallbackQuery{CallbackQueryID: "q1", CacheTime: -1}, wantErr: true},
+		{name: "invalid_url", query: botmsg.AnswerCallbackQuery{CallbackQueryID: "q1", URL: "\x7f"}, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.query.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestChatIntID_ChatUID(t *testing.T) {
+	if got := botmsg.ChatIntID(42).ChatUID(); got != "42" {
+		t.Errorf("ChatUID() = %q, want %q", got, "42")
+	}
+}
+
+func TestTextMessageFromBot(t *testing.T) {
+	m := &botmsg.TextMessageFromBot{}
+
+	if got := m.BotEndpoint(); got != "sendMessage" {
+		t.Errorf("BotEndpoint() = %q, want %q", got, "sendMessage")
+	}
+
+	if got := m.BotMessageType(); got != botmsg.TypeText {
+		t.Errorf("BotMessageType() = %v, want %v", got, botmsg.TypeText)
+	}
+
+	m.IsEdit = true
+	if got := m.BotMessageType(); got != botmsg.TypeEditMessage {
+		t.Errorf("BotMessageType() (IsEdit) = %v, want %v", got, botmsg.TypeEditMessage)
+	}
+}


### PR DESCRIPTION
## What
Adds unit tests for the two previously untested value packages, taking each from **0% → 100%** of statements.

- **botmsg:** `AnswerCallbackQuery.BotMessageType` + `Validate` (all branches: empty id, text >200, negative cache, invalid URL, valid), `ChatIntID.ChatUID`, `TextMessageFromBot.BotEndpoint` + `BotMessageType` (text + edit).
- **botinput:** `Type.String` (in-range + out-of-range fallback), `GetBotInputTypeIdNameString`.

## Note
botinput/type_string.go contains the stringer-generated `func _()` — an unreachable compile-time assertion. It can't be executed by tests, but Go's coverage total doesn't count it, so the package still reports **100.0%**.

## Verification
- ✅ `go vet ./...` clean · `golangci-lint run ./...` 0 issues · all tests pass · both packages 100.0%

🤖 Generated with [Claude Code](https://claude.com/claude-code)