### PR TITLE
security(SEC-4): add per-bot WebhookSecretToken/RequireWebhookSecret to BotSettings

### DIFF
--- a/botsfw/settings.go
+++ b/botsfw/settings.go
@@ -66,6 +66,23 @@ type BotSettings struct {
 	// GAToken is Google Analytics token - TODO: Refactor tu support multiple or move out
 	GAToken string
 
+	// WebhookSecretToken is the secret Telegram (or other platform) sends back on every
+	// webhook call in the `X-Telegram-Bot-Api-Secret-Token` header (set via `secret_token`
+	// when registering the webhook, e.g. Telegram's `setWebhook`). Webhook handlers MUST
+	// verify this value (constant-time) before processing an update, otherwise anyone who
+	// knows the bot's webhook URL can POST forged updates and impersonate any platform user.
+	//
+	// If left empty, no verification is possible for this bot - this is a backward-compat
+	// escape hatch for existing deployments, not a recommended posture. See
+	// RequireWebhookSecret to make an empty secret a hard failure instead.
+	WebhookSecretToken string
+
+	// RequireWebhookSecret, when true, tells a webhook handler to reject all requests for
+	// this bot (rather than just logging a warning) if WebhookSecretToken is empty. Defaults
+	// to false (off) so existing deployments that haven't configured a secret yet keep
+	// working, but every bot SHOULD set WebhookSecretToken and flip this to true.
+	RequireWebhookSecret bool
+
 	// Locale is a default locale for a bot.
 	// While a bot profile can support multiple locales a bot can be dedicated to a specific country/language
 	Locale i18n.Locale


### PR DESCRIPTION
## Context

Part of fixing SEC-4: the Telegram webhook handler in `bots-fw-telegram` processes every incoming update with **no authentication**. `?id=<botCode>` selects the bot, but `botCode` is the bot's public `@username`, not a secret — so anyone who knows/guesses a bot's webhook URL can POST a forged `Update` with an arbitrary `from.id` and be treated as that Telegram user by every module built on the framework (togethered, listus, rosycycle, trackus, debtus).

The real fix (verifying Telegram's `X-Telegram-Bot-Api-Secret-Token` webhook header) lives in `bots-fw-telegram` — see [bots-go-framework/bots-fw-telegram#TODO](https://github.com/bots-go-framework/bots-fw-telegram/pull/new/fable/sec-4-webhook-secret-token) (paired PR, same branch name `fable/sec-4-webhook-secret-token`). That PR needs a place to configure and read the expected secret per bot, following the existing `BotSettings` pattern (`Token`, `PaymentToken`, etc.) rather than inventing a parallel config mechanism — this PR adds that.

## What changed

`botsfw.BotSettings` (`botsfw/settings.go`) gets two new fields:

- **`WebhookSecretToken string`** — the secret expected back on every webhook call (Telegram's `X-Telegram-Bot-Api-Secret-Token`, set via `secret_token` when registering the webhook). Empty by default.
- **`RequireWebhookSecret bool`** — opt-in (default `false`) flag so an operator can turn an unconfigured secret into a hard rejection once the secret has been rolled out for a bot, instead of just a warning.

Purely additive (no existing field/behavior changed), so it's backward compatible for every current consumer.

## Compat posture

- No secret configured + `RequireWebhookSecret == false` (default): existing deployments keep working unauthenticated, but the consuming handler logs a loud warning naming the bot on every request (see the paired PR).
- No secret configured + `RequireWebhookSecret == true`: hard rejection until a secret is set.
- Secret configured: always strictly enforced, regardless of `RequireWebhookSecret`.

## Build/test

```
go build ./...   # ok
go test ./...    # ok, all packages pass
```

## Not done here (by design)

- No release/tag is cut by this PR — per instructions, do not merge/deploy.
- The paired `bots-fw-telegram` PR currently consumes this via a temporary `replace ... => ../bots-fw` in its `go.mod` (marked with a `TODO(SEC-4)` comment) since these fields aren't in a tagged `bots-fw` release yet. Once this PR merges and a version is tagged, that PR needs its `replace` removed and its `require github.com/bots-go-framework/bots-fw` version bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FV3pbooAc9UPpNdiaJuKve