### PR TITLE
Inject environment configuration through context

### DIFF
--- a/botsfw/env_provider.go
+++ b/botsfw/env_provider.go
@@ -1,0 +1,63 @@
+package botsfw
+
+import (
+	"context"
+	"os"
+)
+
+// EnvProvider resolves immutable runtime configuration by name.
+// Implementations must be safe for concurrent use when the same provider is
+// shared by concurrent request contexts.
+type EnvProvider interface {
+	LookupEnv(name string) (value string, ok bool)
+}
+
+// EnvProviderFunc adapts a function to EnvProvider.
+type EnvProviderFunc func(name string) (value string, ok bool)
+
+// LookupEnv implements EnvProvider.
+func (f EnvProviderFunc) LookupEnv(name string) (value string, ok bool) {
+	return f(name)
+}
+
+type osEnvProvider struct{}
+
+func (osEnvProvider) LookupEnv(name string) (value string, ok bool) {
+	return os.LookupEnv(name)
+}
+
+type envProviderContextKey struct{}
+
+var defaultEnvProvider EnvProvider = osEnvProvider{}
+
+// WithEnvProvider returns a child context that resolves environment-backed
+// runtime configuration through provider. It does not mutate process state.
+func WithEnvProvider(ctx context.Context, provider EnvProvider) context.Context {
+	if provider == nil {
+		panic("botsfw.WithEnvProvider: nil provider")
+	}
+	return context.WithValue(ctx, envProviderContextKey{}, provider)
+}
+
+// EnvProviderFromContext returns the context provider, or the process
+// environment provider when no override was attached.
+func EnvProviderFromContext(ctx context.Context) EnvProvider {
+	if ctx != nil {
+		if provider, ok := ctx.Value(envProviderContextKey{}).(EnvProvider); ok && provider != nil {
+			return provider
+		}
+	}
+	return defaultEnvProvider
+}
+
+// LookupEnv resolves name through the provider attached to ctx.
+func LookupEnv(ctx context.Context, name string) (value string, ok bool) {
+	return EnvProviderFromContext(ctx).LookupEnv(name)
+}
+
+// GetEnv resolves name through the provider attached to ctx and returns an
+// empty string when the name is not present.
+func GetEnv(ctx context.Context, name string) string {
+	value, _ := LookupEnv(ctx, name)
+	return value
+}

--- a/botsfw/env_provider_test.go
+++ b/botsfw/env_provider_test.go
@@ -1,0 +1,60 @@
+package botsfw
+
+import (
+	"context"
+	"testing"
+)
+
+func envProviderFromMap(values map[string]string) EnvProvider {
+	return EnvProviderFunc(func(name string) (string, bool) {
+		value, ok := values[name]
+		return value, ok
+	})
+}
+
+func TestEnvProviderDefaultsToProcessEnvironment(t *testing.T) {
+	const name = "BOTFW_ENV_PROVIDER_DEFAULT_TEST"
+	t.Setenv(name, "from-process")
+
+	value, ok := LookupEnv(context.Background(), name)
+	if !ok || value != "from-process" {
+		t.Fatalf("LookupEnv(%q) = %q, %v; want from-process, true", name, value, ok)
+	}
+}
+
+func TestWithEnvProviderRejectsNil(t *testing.T) {
+	defer func() {
+		if recovered := recover(); recovered != "botsfw.WithEnvProvider: nil provider" {
+			t.Fatalf("panic = %v, want nil-provider panic", recovered)
+		}
+	}()
+	WithEnvProvider(context.Background(), nil)
+}
+
+func TestContextEnvProvidersAreIndependent(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name  string
+		value string
+	}{
+		{name: "first", value: "first-value"},
+		{name: "second", value: "second-value"},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := WithEnvProvider(context.Background(), envProviderFromMap(map[string]string{
+				"SHARED_NAME": test.value,
+			}))
+			for i := 0; i < 1000; i++ {
+				if got := GetEnv(ctx, "SHARED_NAME"); got != test.value {
+					t.Fatalf("GetEnv() = %q, want %q", got, test.value)
+				}
+				if _, ok := LookupEnv(ctx, "MISSING"); ok {
+					t.Fatal("LookupEnv(MISSING) unexpectedly reported a value")
+				}
+			}
+		})
+	}
+}

--- a/botsfw/settings.go
+++ b/botsfw/settings.go
@@ -6,7 +6,6 @@ import (
 	"github.com/bots-go-framework/bots-fw-store/botsfwstore"
 	"github.com/bots-go-framework/bots-fw/botsfwconst"
 	"github.com/strongo/i18n"
-	"os"
 	"strings"
 )
 
@@ -87,6 +86,22 @@ func NewBotSettings(
 	locale i18n.Locale,
 	store botsfwstore.StateStore,
 ) BotSettings {
+	return NewBotSettingsWithContext(
+		context.Background(), platform, environment, profile, code, id, token, gaToken, locale, store,
+	)
+}
+
+// NewBotSettingsWithContext configures a bot application using the
+// environment provider attached to ctx for optional token fallbacks.
+func NewBotSettingsWithContext(
+	ctx context.Context,
+	platform botsfwconst.Platform,
+	environment string,
+	profile BotProfile,
+	code, id, token, gaToken string,
+	locale i18n.Locale,
+	store botsfwstore.StateStore,
+) BotSettings {
 	if platform == "" {
 		panic("NewBotSettings: missing required parameter: platform")
 	}
@@ -98,14 +113,14 @@ func NewBotSettings(
 	}
 	if token == "" {
 		envVarKey := fmt.Sprintf("%s_BOT_TOKEN_%s", strings.ToUpper(string(platform)), strings.ToUpper(code))
-		token = os.Getenv(envVarKey)
+		token = GetEnv(ctx, envVarKey)
 		if token == "" {
 			panic("NewBotSettings: missing required parameter 'token' and no environment variable " + envVarKey)
 		}
 	}
 	if gaToken == "" {
 		envVarKey := fmt.Sprintf("%s_GA_TOKEN_%s", strings.ToUpper(string(platform)), strings.ToUpper(code))
-		gaToken = os.Getenv(envVarKey)
+		gaToken = GetEnv(ctx, envVarKey)
 	}
 	if locale.Code5 == "" {
 		panic("NewBotSettings: missing required parameter: Locale.Code5")

--- a/botsfw/settings_test.go
+++ b/botsfw/settings_test.go
@@ -1,6 +1,7 @@
 package botsfw
 
 import (
+	"context"
 	"testing"
 
 	"github.com/bots-go-framework/bots-fw-store/botsfwstore/botsfwstoretest"
@@ -76,6 +77,30 @@ func TestNewBotSettings(t *testing.T) {
 		assert.Equal(t, i18n.LocaleEnUS, bs.Locale)
 		assert.Same(t, store, bs.Store)
 	})
+}
+
+func TestNewBotSettingsWithContextUsesEnvProvider(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithEnvProvider(context.Background(), envProviderFromMap(map[string]string{
+		"TELEGRAM_BOT_TOKEN_MYBOT": "context-token",
+		"TELEGRAM_GA_TOKEN_MYBOT":  "context-ga-token",
+	}))
+	settings := NewBotSettingsWithContext(
+		ctx,
+		"telegram",
+		"test",
+		newTestProfile("profile"),
+		"mybot",
+		"",
+		"",
+		"",
+		i18n.LocaleEnUS,
+		&botsfwstoretest.FakeStateStore{},
+	)
+
+	assert.Equal(t, "context-token", settings.Token)
+	assert.Equal(t, "context-ga-token", settings.GAToken)
 }
 
 func TestNewBotSettingsBy(t *testing.T) {

--- a/botswebhook/router.go
+++ b/botswebhook/router.go
@@ -12,7 +12,6 @@ import (
 	"github.com/strongo/logus"
 	"github.com/strongo/validation"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 )
@@ -978,13 +977,14 @@ const defaultResponseChannelEnv = "BOTSFW_DEFAULT_RESPONSE_CHANNEL"
 // explicitly choose one. The efficient webhook response is the default; set
 // BOTSFW_DEFAULT_RESPONSE_CHANNEL=https to use the Bot API instead.
 func defaultResponseChannel(ctx context.Context) botmsg.BotAPISendMessageChannel {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv(defaultResponseChannelEnv))) {
+	configured := botsfw.GetEnv(ctx, defaultResponseChannelEnv)
+	switch strings.ToLower(strings.TrimSpace(configured)) {
 	case "", "response":
 		return botsfw.BotAPISendMessageOverResponse
 	case "https":
 		return botsfw.BotAPISendMessageOverHTTPS
 	default:
-		log.Warningf(ctx, "Unknown %s value %q; using response", defaultResponseChannelEnv, os.Getenv(defaultResponseChannelEnv))
+		log.Warningf(ctx, "Unknown %s value %q; using response", defaultResponseChannelEnv, configured)
 		return botsfw.BotAPISendMessageOverResponse
 	}
 }

--- a/botswebhook/router_dispatch_test.go
+++ b/botswebhook/router_dispatch_test.go
@@ -1430,7 +1430,6 @@ func TestAcknowledgeCallbackQuery(t *testing.T) {
 }
 
 func TestDefaultResponseChannel(t *testing.T) {
-	ctx := context.Background()
 	for _, tt := range []struct {
 		name  string
 		value string
@@ -1441,8 +1440,19 @@ func TestDefaultResponseChannel(t *testing.T) {
 		{name: "https", value: "https", want: botsfw.BotAPISendMessageOverHTTPS},
 		{name: "invalid", value: "other", want: botsfw.BotAPISendMessageOverResponse},
 	} {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv(defaultResponseChannelEnv, tt.value)
+			t.Parallel()
+			values := map[string]string{}
+			if tt.value != "" {
+				values[defaultResponseChannelEnv] = tt.value
+			}
+			ctx := botsfw.WithEnvProvider(context.Background(), botsfw.EnvProviderFunc(
+				func(name string) (string, bool) {
+					value, ok := values[name]
+					return value, ok
+				},
+			))
 			if got := defaultResponseChannel(ctx); got != tt.want {
 				t.Errorf("defaultResponseChannel() = %q, want %q", got, tt.want)
 			}


### PR DESCRIPTION
## What changed

- add an optional context-scoped EnvProvider with an OS-backed default
- add NewBotSettingsWithContext while preserving NewBotSettings compatibility
- resolve bot token, analytics token, and default response channel through the provider
- prove separate contexts can use different values concurrently without process-global mutation

## Why

Direct process-environment reads force otherwise isolated bot runtimes and tests to share mutable process configuration. Context-scoped providers let immutable profiles remain shared while each runtime supplies independent configuration.

Closes #86.

## Validation

- go test ./...
- Dockerized Go 1.25 race suite: go test -race ./...
- go vet ./...
- focused provider/settings/router coverage: all changed production functions 100%
- git diff --check
