### PR TITLE
Harden the webhook HTTP error envelope

### DIFF
--- a/botswebhook/driver.go
+++ b/botswebhook/driver.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"runtime/debug"
+	"strings"
+
 	"github.com/bots-go-framework/bots-fw/botinput"
 	"github.com/bots-go-framework/bots-fw/botsfw"
 	"github.com/strongo/analytics"
 	"github.com/strongo/logus"
-	"net/http"
-	"runtime/debug"
-	"strings"
 )
 
 // ErrorIcon is used to report errors to user
@@ -66,12 +67,31 @@ func (d webhookDriver) HandleWebhook(w http.ResponseWriter, r *http.Request, web
 		panic("Parameter 'webhookHandler WebhookHandler' is nil")
 	}
 
-	ctx := d.botHost.Context(r)
+	response := newWebhookResponse(w)
+	w = response.writer
+	ctx := r.Context()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			log.Criticalf(ctx, "Panic recovered while handling webhook: %v\n\nStack trace:\n%s", recovered, debug.Stack())
+			d.handleProcessingError(ctx, response, fmt.Errorf("panic while handling webhook: %v", recovered), "Panic while handling webhook")
+		}
+	}()
+
+	if r.ContentLength > MaxWebhookRequestBodyBytes {
+		log.Warningf(ctx, "webhook request body exceeds limit: content_length=%d, limit=%d", r.ContentLength, MaxWebhookRequestBodyBytes)
+		response.writeError(http.StatusRequestEntityTooLarge)
+		return
+	}
+	if r.Body != nil {
+		r.Body = http.MaxBytesReader(w, r.Body, MaxWebhookRequestBodyBytes)
+	}
+
+	ctx = d.botHost.Context(r)
 
 	// A bot can receiver multiple messages in a single request
 	botContext, entriesWithInputs, err := webhookHandler.GetBotContextAndInputs(ctx, r)
 
-	if d.invalidContextOrInputs(ctx, w, r, botContext, entriesWithInputs, err) {
+	if d.invalidContextOrInputs(ctx, response, r, botContext, entriesWithInputs, err) {
 		return
 	}
 
@@ -90,30 +110,26 @@ func (d webhookDriver) HandleWebhook(w http.ResponseWriter, r *http.Request, web
 	//	}
 	//}()
 
-	handleErrorAndReturnHttpError := func(err error, message string) {
-		logus.Errorf(ctx, "%s: %v", message, err)
-		errText := fmt.Sprintf("%s: %s: %v", http.StatusText(http.StatusInternalServerError), message, err)
-		http.Error(w, errText, http.StatusInternalServerError)
-	}
-
-	handleErrorAndReturnHttpOK := func(err error, message string) {
-		logus.Errorf(ctx, "%s: %v\nHTTP will return status OK", message, err)
-		w.WriteHeader(http.StatusOK)
+	handleError := func(err error, message string) {
+		d.handleProcessingError(ctx, response, err, message)
 	}
 
 	for _, entryWithInputs := range entriesWithInputs {
 		for i, input := range entryWithInputs.Inputs {
-			var handleError func(err error, message string)
-			if input.InputType() == botinput.TypeCallbackQuery {
-				handleError = handleErrorAndReturnHttpOK
-			} else {
-				handleError = handleErrorAndReturnHttpError
-			}
 			if err = d.processWebhookInput(ctx, w, r, webhookHandler, botContext, i, input, handleError); err != nil {
 				log.Errorf(ctx, "Failed to process input[%v]: %v", i, err)
 			}
 		}
 	}
+}
+
+func (webhookDriver) handleProcessingError(ctx context.Context, response *webhookResponse, err error, operation string) {
+	if response.isCommitted() {
+		logus.Errorf(ctx, "%s: %v; response already committed", operation, err)
+		return
+	}
+	logus.Errorf(ctx, "%s: %v", operation, err)
+	response.writeError(http.StatusInternalServerError)
 }
 
 func (d webhookDriver) processWebhookInput(
@@ -134,9 +150,14 @@ func (d webhookDriver) processWebhookInput(
 		log.Debugf(ctx, "driver.deferred(recover) - checking for panic & flush GA")
 
 		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("panic while processing webhook input: %v", recovered)
 			stack := string(debug.Stack())
 			messageText := fmt.Sprintf("Panic: %v\n\nStack trace:\n%s\n\n%s", recovered, stack, d.panicTextFooter)
 			log.Criticalf(ctx, "Panic recovered: %s", messageText)
+
+			runPanicRecoveryStep(ctx, "write panic response", func() {
+				handleError(err, "Panic while processing webhook input")
+			})
 
 			const maxLen = 3 * 1024
 			if len(messageText) > maxLen {
@@ -163,19 +184,18 @@ func (d webhookDriver) processWebhookInput(
 
 			if whc != nil {
 				runPanicRecoveryStep(ctx, "report panic to user", func() {
-					var chatID string
-					if chatID, err = whc.Input().BotChatID(); err == nil && chatID != "" {
+					if chatID, chatIDErr := whc.Input().BotChatID(); chatIDErr == nil && chatID != "" {
 						if responder := whc.Responder(); responder != nil {
 							m := whc.NewMessage(ErrorIcon + " " + panicUserMessage)
-							if _, err = botsfw.SendMessageThroughGate(ctx, responder, m, botsfw.BotAPISendMessageOverResponse); err != nil {
-								if botsfw.IsSendNotPermitted(err) {
+							if _, sendErr := botsfw.SendMessageThroughGate(ctx, responder, m, botsfw.BotAPISendMessageOverHTTPS); sendErr != nil {
+								if botsfw.IsSendNotPermitted(sendErr) {
 									// A gated platform will not accept an unsolicited
 									// message here. Reporting the panic to the user is
 									// best-effort; the panic is already logged and sent
 									// to analytics above.
-									log.Warningf(ctx, "not reporting error to user: %v", err)
+									log.Warningf(ctx, "not reporting error to user: %v", sendErr)
 								} else {
-									log.Errorf(ctx, fmt.Errorf("failed to report error to user: %w", err).Error())
+									log.Errorf(ctx, fmt.Errorf("failed to report error to user: %w", sendErr).Error())
 								}
 							}
 						}
@@ -191,7 +211,9 @@ func (d webhookDriver) processWebhookInput(
 	d.logInput(ctx, i, input)
 	store := botContext.BotSettings.Store
 	if store == nil {
-		return fmt.Errorf("bot %q has no state store", botContext.BotSettings.Code)
+		err = fmt.Errorf("bot %q has no state store", botContext.BotSettings.Code)
+		handleError(err, "Failed to prepare webhook state")
+		return
 	}
 	whcArgs := botsfw.NewCreateWebhookContextArgs(r, botContext.AppContext, *botContext, input, store)
 	if whc, err = webhookHandler.CreateWebhookContext(whcArgs); err != nil {
@@ -228,13 +250,21 @@ func runPanicRecoveryStep(ctx context.Context, operation string, action func()) 
 	action()
 }
 
-func (webhookDriver) invalidContextOrInputs(c context.Context, w http.ResponseWriter, r *http.Request, botContext *botsfw.BotContext, entriesWithInputs []botinput.EntryInputs, err error) bool {
+func (d webhookDriver) invalidContextOrInputs(c context.Context, response *webhookResponse, r *http.Request, botContext *botsfw.BotContext, entriesWithInputs []botinput.EntryInputs, err error) bool {
 	if err != nil {
+		var maxBytesError *http.MaxBytesError
+		if errors.As(err, &maxBytesError) {
+			log.Warningf(c, "webhook request body exceeds limit: limit=%d", maxBytesError.Limit)
+			response.writeError(http.StatusRequestEntityTooLarge)
+			return true
+		}
 		var errAuthFailed botsfw.ErrAuthFailed
 		if errors.As(err, &errAuthFailed) {
 			log.Warningf(c, "Auth failed: %v", err)
-			http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+			response.writeError(http.StatusForbidden)
+			return true
 		}
+		d.handleProcessingError(c, response, err, "Failed to parse webhook request")
 		return true
 	}
 	if botContext == nil {
@@ -245,9 +275,11 @@ func (webhookDriver) invalidContextOrInputs(c context.Context, w http.ResponseWr
 		} else {
 			log.Errorf(c, "botContext == nil, len(entriesWithInputs) == %v", len(entriesWithInputs))
 		}
+		response.writeError(http.StatusInternalServerError)
 		return true
 	} else if entriesWithInputs == nil {
 		log.Errorf(c, "entriesWithInputs == nil")
+		response.writeError(http.StatusInternalServerError)
 		return true
 	}
 
@@ -255,13 +287,13 @@ func (webhookDriver) invalidContextOrInputs(c context.Context, w http.ResponseWr
 	case botsfw.EnvLocal:
 		if !isRunningLocally(r.Host) {
 			log.Warningf(c, "whc.GetBotSettings().Mode == Local, host: %v", r.Host)
-			w.WriteHeader(http.StatusBadRequest)
+			response.writeError(http.StatusBadRequest)
 			return true
 		}
 	case botsfw.EnvProduction:
 		if isRunningLocally(r.Host) {
 			log.Warningf(c, "whc.GetBotSettings().Mode == Production, host: %v", r.Host)
-			w.WriteHeader(http.StatusBadRequest)
+			response.writeError(http.StatusBadRequest)
 			return true
 		}
 	}

--- a/botswebhook/driver.go
+++ b/botswebhook/driver.go
@@ -17,6 +17,8 @@ import (
 // ErrorIcon is used to report errors to user
 var ErrorIcon = "🚨"
 
+const panicUserMessage = "Internal error. Please try again later."
+
 // webhookDriver keeps information about bots and map requests to appropriate handlers
 type webhookDriver struct {
 	Analytics       AnalyticsSettings
@@ -143,30 +145,42 @@ func (d webhookDriver) processWebhookInput(
 
 			// Initiate Google Analytics Measurement API client
 
-			if analyticsEnabled := d.Analytics.Enabled != nil && d.Analytics.Enabled(r) || botContext.BotSettings.Env == botsfw.EnvProduction; analyticsEnabled {
-				d.reportPanicToAnalytics(ctx, whc, messageText)
+			var analyticsEnabled bool
+			runPanicRecoveryStep(ctx, "check analytics configuration", func() {
+				analyticsEnabled = d.Analytics.Enabled != nil && d.Analytics.Enabled(r) || botContext.BotSettings.Env == botsfw.EnvProduction
+			})
+			if analyticsEnabled {
+				if whc != nil {
+					runPanicRecoveryStep(ctx, "report panic to analytics", func() {
+						d.reportPanicToAnalytics(ctx, whc, messageText)
+					})
+				} else {
+					log.Warningf(ctx, "not reporting panic to analytics: webhook context is unavailable")
+				}
 			} else {
 				log.Debugf(ctx, "botContext.BotSettings.Env=%s, analyticsEnabled=%t", botContext.BotSettings.Env, analyticsEnabled)
 			}
 
 			if whc != nil {
-				var chatID string
-				if chatID, err = whc.Input().BotChatID(); err == nil && chatID != "" {
-					if responder := whc.Responder(); responder != nil {
-						m := whc.NewMessage(ErrorIcon + " " + messageText)
-						if _, err = botsfw.SendMessageThroughGate(ctx, responder, m, botsfw.BotAPISendMessageOverResponse); err != nil {
-							if botsfw.IsSendNotPermitted(err) {
-								// A gated platform will not accept an unsolicited
-								// message here. Reporting the panic to the user is
-								// best-effort; the panic is already logged and sent
-								// to analytics above.
-								log.Warningf(ctx, "not reporting error to user: %v", err)
-							} else {
-								log.Errorf(ctx, fmt.Errorf("failed to report error to user: %w", err).Error())
+				runPanicRecoveryStep(ctx, "report panic to user", func() {
+					var chatID string
+					if chatID, err = whc.Input().BotChatID(); err == nil && chatID != "" {
+						if responder := whc.Responder(); responder != nil {
+							m := whc.NewMessage(ErrorIcon + " " + panicUserMessage)
+							if _, err = botsfw.SendMessageThroughGate(ctx, responder, m, botsfw.BotAPISendMessageOverResponse); err != nil {
+								if botsfw.IsSendNotPermitted(err) {
+									// A gated platform will not accept an unsolicited
+									// message here. Reporting the panic to the user is
+									// best-effort; the panic is already logged and sent
+									// to analytics above.
+									log.Warningf(ctx, "not reporting error to user: %v", err)
+								} else {
+									log.Errorf(ctx, fmt.Errorf("failed to report error to user: %w", err).Error())
+								}
 							}
 						}
 					}
-				}
+				})
 			}
 		}
 	}()
@@ -203,6 +217,15 @@ func (d webhookDriver) processWebhookInput(
 	}
 
 	return
+}
+
+func runPanicRecoveryStep(ctx context.Context, operation string, action func()) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			log.Criticalf(ctx, "panic recovery step failed: operation=%q, panic_type=%T", operation, recovered)
+		}
+	}()
+	action()
 }
 
 func (webhookDriver) invalidContextOrInputs(c context.Context, w http.ResponseWriter, r *http.Request, botContext *botsfw.BotContext, entriesWithInputs []botinput.EntryInputs, err error) bool {

--- a/botswebhook/driver_dispatch_test.go
+++ b/botswebhook/driver_dispatch_test.go
@@ -42,7 +42,7 @@ func TestInvalidContextOrInputs(t *testing.T) {
 	t.Run("error_returns_true", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPost, "/webhook", nil)
-		result := d.invalidContextOrInputs(ctx, w, r, nil, nil, assert.AnError)
+		result := d.invalidContextOrInputs(ctx, newWebhookResponse(w), r, nil, nil, assert.AnError)
 		assert.True(t, result)
 	})
 
@@ -50,7 +50,7 @@ func TestInvalidContextOrInputs(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPost, "/webhook", nil)
 		err := botsfw.ErrAuthFailed("auth failed")
-		result := d.invalidContextOrInputs(ctx, w, r, nil, nil, err)
+		result := d.invalidContextOrInputs(ctx, newWebhookResponse(w), r, nil, nil, err)
 		assert.True(t, result)
 		assert.Equal(t, http.StatusForbidden, w.Code)
 	})
@@ -58,14 +58,14 @@ func TestInvalidContextOrInputs(t *testing.T) {
 	t.Run("nil_botContext_nil_inputs", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPost, "/webhook", nil)
-		result := d.invalidContextOrInputs(ctx, w, r, nil, nil, nil)
+		result := d.invalidContextOrInputs(ctx, newWebhookResponse(w), r, nil, nil, nil)
 		assert.True(t, result)
 	})
 
 	t.Run("nil_botContext_empty_inputs", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPost, "/webhook", nil)
-		result := d.invalidContextOrInputs(ctx, w, r, nil, []botinput.EntryInputs{}, nil)
+		result := d.invalidContextOrInputs(ctx, newWebhookResponse(w), r, nil, []botinput.EntryInputs{}, nil)
 		assert.True(t, result)
 	})
 
@@ -73,7 +73,7 @@ func TestInvalidContextOrInputs(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodPost, "/webhook", nil)
 		entries := []botinput.EntryInputs{{}}
-		result := d.invalidContextOrInputs(ctx, w, r, nil, entries, nil)
+		result := d.invalidContextOrInputs(ctx, newWebhookResponse(w), r, nil, entries, nil)
 		assert.True(t, result)
 	})
 
@@ -83,7 +83,7 @@ func TestInvalidContextOrInputs(t *testing.T) {
 		bc := &botsfw.BotContext{
 			BotSettings: &botsfw.BotSettings{Env: "production"},
 		}
-		result := d.invalidContextOrInputs(ctx, w, r, bc, nil, nil)
+		result := d.invalidContextOrInputs(ctx, newWebhookResponse(w), r, bc, nil, nil)
 		assert.True(t, result)
 	})
 
@@ -94,7 +94,7 @@ func TestInvalidContextOrInputs(t *testing.T) {
 			BotSettings: &botsfw.BotSettings{Env: botsfw.EnvLocal},
 		}
 		entries := []botinput.EntryInputs{{}}
-		result := d.invalidContextOrInputs(ctx, w, r, bc, entries, nil)
+		result := d.invalidContextOrInputs(ctx, newWebhookResponse(w), r, bc, entries, nil)
 		assert.False(t, result)
 	})
 
@@ -105,7 +105,7 @@ func TestInvalidContextOrInputs(t *testing.T) {
 			BotSettings: &botsfw.BotSettings{Env: botsfw.EnvLocal},
 		}
 		entries := []botinput.EntryInputs{{}}
-		result := d.invalidContextOrInputs(ctx, w, r, bc, entries, nil)
+		result := d.invalidContextOrInputs(ctx, newWebhookResponse(w), r, bc, entries, nil)
 		assert.True(t, result)
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
@@ -117,7 +117,7 @@ func TestInvalidContextOrInputs(t *testing.T) {
 			BotSettings: &botsfw.BotSettings{Env: botsfw.EnvProduction},
 		}
 		entries := []botinput.EntryInputs{{}}
-		result := d.invalidContextOrInputs(ctx, w, r, bc, entries, nil)
+		result := d.invalidContextOrInputs(ctx, newWebhookResponse(w), r, bc, entries, nil)
 		assert.True(t, result)
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
@@ -129,7 +129,7 @@ func TestInvalidContextOrInputs(t *testing.T) {
 			BotSettings: &botsfw.BotSettings{Env: botsfw.EnvProduction},
 		}
 		entries := []botinput.EntryInputs{{}}
-		result := d.invalidContextOrInputs(ctx, w, r, bc, entries, nil)
+		result := d.invalidContextOrInputs(ctx, newWebhookResponse(w), r, bc, entries, nil)
 		assert.False(t, result)
 	})
 }

--- a/botswebhook/driver_panic_test.go
+++ b/botswebhook/driver_panic_test.go
@@ -53,7 +53,7 @@ func TestProcessWebhookInput_PanicResponseIsSanitized(t *testing.T) {
 
 	var sent botmsg.MessageFromBot
 	responder.EXPECT().
-		SendMessage(gomock.Any(), gomock.Any(), botsfw.BotAPISendMessageOverResponse).
+		SendMessage(gomock.Any(), gomock.Any(), botsfw.BotAPISendMessageOverHTTPS).
 		DoAndReturn(func(_ context.Context, m botmsg.MessageFromBot, _ botmsg.BotAPISendMessageChannel) (botsfw.OnMessageSentResponse, error) {
 			sent = m
 			return botsfw.OnMessageSentResponse{}, nil
@@ -67,18 +67,28 @@ func TestProcessWebhookInput_PanicResponseIsSanitized(t *testing.T) {
 	}
 	botContext := panicTestBotContext()
 	request := httptest.NewRequest(http.MethodPost, "/webhook", nil)
+	recorder := httptest.NewRecorder()
+	response := newWebhookResponse(recorder)
 
 	if err := driver.processWebhookInput(
 		context.Background(),
-		httptest.NewRecorder(),
+		response.writer,
 		request,
 		handler,
 		botContext,
 		0,
 		input,
-		func(error, string) {},
-	); err != nil {
-		t.Fatalf("processWebhookInput() error = %v", err)
+		func(err error, operation string) {
+			driver.handleProcessingError(context.Background(), response, err, operation)
+		},
+	); err == nil {
+		t.Fatal("processWebhookInput() error = nil, want recovered panic")
+	}
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("HTTP status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+	}
+	if recorder.Body.String() != http.StatusText(http.StatusInternalServerError)+"\n" {
+		t.Fatalf("HTTP body = %q, want generic internal error", recorder.Body.String())
 	}
 
 	if sent.Text != wantText {

--- a/botswebhook/driver_panic_test.go
+++ b/botswebhook/driver_panic_test.go
@@ -1,0 +1,180 @@
+package botswebhook
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bots-go-framework/bots-fw-store/botsfwstore/botsfwstoretest"
+	"github.com/bots-go-framework/bots-fw/botinput"
+	"github.com/bots-go-framework/bots-fw/botmsg"
+	"github.com/bots-go-framework/bots-fw/botsfw"
+	"github.com/bots-go-framework/bots-fw/mocks/mock_botinput"
+	"github.com/bots-go-framework/bots-fw/mocks/mock_botsfw"
+	"go.uber.org/mock/gomock"
+)
+
+func TestProcessWebhookInput_PanicResponseIsSanitized(t *testing.T) {
+	const (
+		panicSecret  = "PANIC-DETAIL-MUST-STAY-INTERNAL"
+		footerSecret = "PRIVATE-OPERATOR-FOOTER"
+	)
+
+	ctrl := gomock.NewController(t)
+	input := newDriverPanicTextInput(ctrl)
+	responder := mock_botsfw.NewMockWebhookResponder(ctrl)
+	analytics := mock_botsfw.NewMockWebhookAnalytics(ctrl)
+	whc := mock_botsfw.NewMockWebhookContext(ctrl)
+	handler := mock_botsfw.NewMockWebhookHandler(ctrl)
+
+	handler.EXPECT().
+		CreateWebhookContext(gomock.Any()).
+		Return(whc, nil)
+	whc.EXPECT().
+		ChatData().
+		DoAndReturn(func() any {
+			panic(panicSecret)
+		})
+	whc.EXPECT().Analytics().Return(analytics)
+	analytics.EXPECT().
+		Enqueue(gomock.Any()).
+		Do(func(any) {
+			panic("analytics re-entered the failing context")
+		})
+	whc.EXPECT().Input().Return(input)
+	whc.EXPECT().Responder().Return(responder)
+
+	wantText := ErrorIcon + " " + panicUserMessage
+	whc.EXPECT().
+		NewMessage(wantText).
+		Return(botmsg.MessageFromBot{TextMessageFromBot: botmsg.TextMessageFromBot{Text: wantText}})
+
+	var sent botmsg.MessageFromBot
+	responder.EXPECT().
+		SendMessage(gomock.Any(), gomock.Any(), botsfw.BotAPISendMessageOverResponse).
+		DoAndReturn(func(_ context.Context, m botmsg.MessageFromBot, _ botmsg.BotAPISendMessageChannel) (botsfw.OnMessageSentResponse, error) {
+			sent = m
+			return botsfw.OnMessageSentResponse{}, nil
+		})
+
+	driver := webhookDriver{
+		Analytics: AnalyticsSettings{
+			Enabled: func(*http.Request) bool { return true },
+		},
+		panicTextFooter: footerSecret,
+	}
+	botContext := panicTestBotContext()
+	request := httptest.NewRequest(http.MethodPost, "/webhook", nil)
+
+	if err := driver.processWebhookInput(
+		context.Background(),
+		httptest.NewRecorder(),
+		request,
+		handler,
+		botContext,
+		0,
+		input,
+		func(error, string) {},
+	); err != nil {
+		t.Fatalf("processWebhookInput() error = %v", err)
+	}
+
+	if sent.Text != wantText {
+		t.Fatalf("sent text = %q, want %q", sent.Text, wantText)
+	}
+	for _, privateValue := range []string{panicSecret, footerSecret, "Stack trace", "driver_panic_test.go"} {
+		if strings.Contains(sent.Text, privateValue) {
+			t.Fatalf("panic response exposes private diagnostic %q: %q", privateValue, sent.Text)
+		}
+	}
+}
+
+func TestProcessWebhookInput_PanicInUserNotificationDoesNotRepanic(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	input := newDriverPanicTextInput(ctrl)
+	whc := mock_botsfw.NewMockWebhookContext(ctrl)
+	handler := mock_botsfw.NewMockWebhookHandler(ctrl)
+
+	handler.EXPECT().
+		CreateWebhookContext(gomock.Any()).
+		Return(whc, nil)
+	whc.EXPECT().
+		ChatData().
+		DoAndReturn(func() any {
+			panic("initial panic")
+		})
+	whc.EXPECT().
+		Input().
+		DoAndReturn(func() botinput.InputMessage {
+			panic("notification hook panic")
+		})
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("processWebhookInput() recovery panicked again: %v", recovered)
+		}
+	}()
+
+	driver := webhookDriver{}
+	_ = driver.processWebhookInput(
+		context.Background(),
+		httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodPost, "/webhook", nil),
+		handler,
+		panicTestBotContext(),
+		0,
+		input,
+		func(error, string) {},
+	)
+}
+
+func TestProcessWebhookInput_PanicBeforeWebhookContextDoesNotRepanic(t *testing.T) {
+	driver := webhookDriver{
+		Analytics: AnalyticsSettings{
+			Enabled: func(*http.Request) bool { return true },
+		},
+		panicTextFooter: "private footer",
+	}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("processWebhookInput() recovery panicked again: %v", recovered)
+		}
+	}()
+
+	_ = driver.processWebhookInput(
+		context.Background(),
+		httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodPost, "/webhook", nil),
+		nil,
+		panicTestBotContext(),
+		0,
+		nil,
+		func(error, string) {},
+	)
+}
+
+func newDriverPanicTextInput(ctrl *gomock.Controller) *mock_botinput.MockTextMessage {
+	user := mock_botinput.NewMockUser(ctrl)
+	user.EXPECT().GetID().Return("user-id")
+	user.EXPECT().GetFirstName().Return("First")
+	user.EXPECT().GetLastName().Return("Last")
+
+	input := mock_botinput.NewMockTextMessage(ctrl)
+	input.EXPECT().GetSender().Return(user)
+	input.EXPECT().Text().Return("request text")
+	input.EXPECT().BotChatID().Return("chat-id", nil).AnyTimes()
+	return input
+}
+
+func panicTestBotContext() *botsfw.BotContext {
+	return &botsfw.BotContext{
+		BotSettings: &botsfw.BotSettings{
+			Code:  "panic-test",
+			Env:   botsfw.EnvLocal,
+			Store: &botsfwstoretest.FakeStateStore{},
+		},
+	}
+}

--- a/botswebhook/response.go
+++ b/botswebhook/response.go
@@ -1,0 +1,95 @@
+package botswebhook
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"sync/atomic"
+
+	"github.com/felixge/httpsnoop"
+)
+
+// MaxWebhookRequestBodyBytes limits webhook payloads before platform adapters
+// decode them. Webhook bodies are metadata envelopes rather than media uploads;
+// 8 MiB leaves ample room for batched updates while bounding memory use.
+const MaxWebhookRequestBodyBytes int64 = 8 << 20
+
+type webhookResponse struct {
+	raw       http.ResponseWriter
+	writer    http.ResponseWriter
+	committed atomic.Bool
+}
+
+func newWebhookResponse(w http.ResponseWriter) *webhookResponse {
+	response := &webhookResponse{raw: w}
+	response.writer = httpsnoop.Wrap(w, httpsnoop.Hooks{
+		WriteHeader: func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+			return func(statusCode int) {
+				if statusCode < 100 || statusCode > 199 {
+					response.committed.Store(true)
+				}
+				next(statusCode)
+			}
+		},
+		Write: func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+			return func(body []byte) (int, error) {
+				response.committed.Store(true)
+				return next(body)
+			}
+		},
+		WriteString: func(next httpsnoop.WriteStringFunc) httpsnoop.WriteStringFunc {
+			return func(body string) (int, error) {
+				response.committed.Store(true)
+				return next(body)
+			}
+		},
+		ReadFrom: func(next httpsnoop.ReadFromFunc) httpsnoop.ReadFromFunc {
+			return func(source io.Reader) (int64, error) {
+				response.committed.Store(true)
+				return next(source)
+			}
+		},
+		Flush: func(next httpsnoop.FlushFunc) httpsnoop.FlushFunc {
+			return func() {
+				response.committed.Store(true)
+				next()
+			}
+		},
+		FlushError: func(next httpsnoop.FlushErrorFunc) httpsnoop.FlushErrorFunc {
+			return func() error {
+				response.committed.Store(true)
+				return next()
+			}
+		},
+		Hijack: func(next httpsnoop.HijackFunc) httpsnoop.HijackFunc {
+			return func() (net.Conn, *bufio.ReadWriter, error) {
+				connection, readWriter, err := next()
+				if err == nil {
+					response.committed.Store(true)
+				}
+				return connection, readWriter, err
+			}
+		},
+	})
+	return response
+}
+
+func (r *webhookResponse) isCommitted() bool {
+	return r.committed.Load()
+}
+
+// writeError writes a fixed, non-sensitive HTTP error only if no response has
+// been committed. It returns false after a responder has already started the
+// response, allowing callers to log the failure without a second write.
+func (r *webhookResponse) writeError(statusCode int) bool {
+	if !r.committed.CompareAndSwap(false, true) {
+		return false
+	}
+	header := r.raw.Header()
+	header.Set("Content-Type", "text/plain; charset=utf-8")
+	header.Set("X-Content-Type-Options", "nosniff")
+	r.raw.WriteHeader(statusCode)
+	_, _ = io.WriteString(r.raw, http.StatusText(statusCode)+"\n")
+	return true
+}

--- a/botswebhook/response_test.go
+++ b/botswebhook/response_test.go
@@ -1,0 +1,353 @@
+package botswebhook
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bots-go-framework/bots-fw-store/botsfwstore/botsfwstoretest"
+	"github.com/bots-go-framework/bots-fw/botinput"
+	"github.com/bots-go-framework/bots-fw/botsfw"
+	"github.com/bots-go-framework/bots-fw/mocks/mock_botsfw"
+	"go.uber.org/mock/gomock"
+)
+
+func TestHandleWebhook_PreCommitFailuresAreGeneric(t *testing.T) {
+	const secret = "PRIVATE-PROCESS-DETAIL"
+
+	tests := []struct {
+		name string
+		get  func(context.Context, *http.Request) (*botsfw.BotContext, []botinput.EntryInputs, error)
+	}{
+		{
+			name: "error",
+			get: func(context.Context, *http.Request) (*botsfw.BotContext, []botinput.EntryInputs, error) {
+				return nil, nil, errors.New(secret)
+			},
+		},
+		{
+			name: "panic",
+			get: func(context.Context, *http.Request) (*botsfw.BotContext, []botinput.EntryInputs, error) {
+				panic(secret)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			driver := webhookDriver{botHost: testBotHostForDriver{}}
+			driver.HandleWebhook(
+				recorder,
+				httptest.NewRequest(http.MethodPost, "http://localhost/webhook", nil),
+				envelopeWebhookHandler{get: test.get},
+			)
+
+			if recorder.Code != http.StatusInternalServerError {
+				t.Fatalf("HTTP status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+			}
+			if body := recorder.Body.String(); body != http.StatusText(http.StatusInternalServerError)+"\n" {
+				t.Fatalf("HTTP body = %q, want generic error", body)
+			}
+			if strings.Contains(recorder.Body.String(), secret) {
+				t.Fatalf("HTTP body exposes private error: %q", recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleWebhook_PreCommitProcessErrorIsSanitized(t *testing.T) {
+	const secret = "PRIVATE-DISPATCH-DETAIL"
+
+	ctrl := gomock.NewController(t)
+	input := newDriverPanicTextInput(ctrl)
+	whc := mock_botsfw.NewMockWebhookContext(ctrl)
+	whc.EXPECT().ChatData().Return(nil)
+
+	router := envelopeRouter{
+		dispatch: func(botsfw.WebhookHandler, botsfw.WebhookResponder, botsfw.WebhookContext) error {
+			return errors.New(secret)
+		},
+	}
+	botContext := &botsfw.BotContext{
+		BotSettings: &botsfw.BotSettings{
+			Code:    "response-test",
+			Env:     botsfw.EnvLocal,
+			Store:   &botsfwstoretest.FakeStateStore{},
+			Profile: envelopeBotProfile{router: router},
+		},
+	}
+	handler := envelopeWebhookHandler{
+		get: func(context.Context, *http.Request) (*botsfw.BotContext, []botinput.EntryInputs, error) {
+			return botContext, []botinput.EntryInputs{{Inputs: []botinput.InputMessage{input}}}, nil
+		},
+		create: func(botsfw.CreateWebhookContextArgs) (botsfw.WebhookContext, error) {
+			return whc, nil
+		},
+		responder: func(http.ResponseWriter, botsfw.WebhookContext) botsfw.WebhookResponder {
+			return nil
+		},
+	}
+	recorder := httptest.NewRecorder()
+
+	webhookDriver{botHost: testBotHostForDriver{}}.HandleWebhook(
+		recorder,
+		httptest.NewRequest(http.MethodPost, "http://localhost/webhook", nil),
+		handler,
+	)
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("HTTP status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+	}
+	if body := recorder.Body.String(); body != http.StatusText(http.StatusInternalServerError)+"\n" {
+		t.Fatalf("HTTP body = %q, want generic error", body)
+	}
+	if strings.Contains(recorder.Body.String(), secret) {
+		t.Fatalf("HTTP body exposes private process error: %q", recorder.Body.String())
+	}
+}
+
+func TestHandleWebhook_PostCommitFailuresDoNotRewriteResponse(t *testing.T) {
+	const (
+		committedBody = "platform response"
+		secret        = "PRIVATE-POST-COMMIT-DETAIL"
+	)
+
+	tests := []struct {
+		name     string
+		dispatch func() error
+	}{
+		{name: "error", dispatch: func() error { return errors.New(secret) }},
+		{name: "panic", dispatch: func() error { panic(secret) }},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			input := newDriverPanicTextInput(ctrl)
+			whc := mock_botsfw.NewMockWebhookContext(ctrl)
+			whc.EXPECT().ChatData().Return(nil)
+			if test.name == "panic" {
+				whc.EXPECT().Input().Return(input)
+				whc.EXPECT().Responder().Return(nil)
+			}
+
+			router := envelopeRouter{
+				dispatch: func(botsfw.WebhookHandler, botsfw.WebhookResponder, botsfw.WebhookContext) error {
+					return test.dispatch()
+				},
+			}
+			botContext := &botsfw.BotContext{
+				BotSettings: &botsfw.BotSettings{
+					Code:    "response-test",
+					Env:     botsfw.EnvLocal,
+					Store:   &botsfwstoretest.FakeStateStore{},
+					Profile: envelopeBotProfile{router: router},
+				},
+			}
+			handler := envelopeWebhookHandler{
+				get: func(context.Context, *http.Request) (*botsfw.BotContext, []botinput.EntryInputs, error) {
+					return botContext, []botinput.EntryInputs{{Inputs: []botinput.InputMessage{input}}}, nil
+				},
+				create: func(botsfw.CreateWebhookContextArgs) (botsfw.WebhookContext, error) {
+					return whc, nil
+				},
+				responder: func(w http.ResponseWriter, _ botsfw.WebhookContext) botsfw.WebhookResponder {
+					w.WriteHeader(http.StatusAccepted)
+					_, _ = io.WriteString(w, committedBody)
+					return nil
+				},
+			}
+
+			recorder := httptest.NewRecorder()
+			driver := webhookDriver{botHost: testBotHostForDriver{}}
+			driver.HandleWebhook(
+				recorder,
+				httptest.NewRequest(http.MethodPost, "http://localhost/webhook", nil),
+				handler,
+			)
+
+			if recorder.Code != http.StatusAccepted {
+				t.Fatalf("HTTP status = %d, want %d", recorder.Code, http.StatusAccepted)
+			}
+			if body := recorder.Body.String(); body != committedBody {
+				t.Fatalf("HTTP body = %q, want unchanged %q", body, committedBody)
+			}
+			if strings.Contains(recorder.Body.String(), secret) {
+				t.Fatalf("HTTP body exposes private error: %q", recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleWebhook_RejectsOversizeBody(t *testing.T) {
+	handlerCalled := false
+	handler := envelopeWebhookHandler{
+		get: func(context.Context, *http.Request) (*botsfw.BotContext, []botinput.EntryInputs, error) {
+			handlerCalled = true
+			return nil, nil, nil
+		},
+	}
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"http://localhost/webhook",
+		io.LimitReader(strings.NewReader(strings.Repeat("x", 1024)), MaxWebhookRequestBodyBytes+1),
+	)
+	request.ContentLength = MaxWebhookRequestBodyBytes + 1
+	recorder := httptest.NewRecorder()
+
+	webhookDriver{botHost: testBotHostForDriver{}}.HandleWebhook(recorder, request, handler)
+
+	if handlerCalled {
+		t.Fatal("platform handler was called for an oversized request")
+	}
+	if recorder.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("HTTP status = %d, want %d", recorder.Code, http.StatusRequestEntityTooLarge)
+	}
+	if body := recorder.Body.String(); body != http.StatusText(http.StatusRequestEntityTooLarge)+"\n" {
+		t.Fatalf("HTTP body = %q, want generic request-too-large error", body)
+	}
+}
+
+func TestHandleWebhook_BoundsBodyWithUnknownLength(t *testing.T) {
+	handler := envelopeWebhookHandler{
+		get: func(_ context.Context, request *http.Request) (*botsfw.BotContext, []botinput.EntryInputs, error) {
+			_, err := io.ReadAll(request.Body)
+			return nil, nil, err
+		},
+	}
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"http://localhost/webhook",
+		strings.NewReader(strings.Repeat("x", int(MaxWebhookRequestBodyBytes)+1)),
+	)
+	request.ContentLength = -1
+	recorder := httptest.NewRecorder()
+
+	webhookDriver{botHost: testBotHostForDriver{}}.HandleWebhook(recorder, request, handler)
+
+	if recorder.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("HTTP status = %d, want %d", recorder.Code, http.StatusRequestEntityTooLarge)
+	}
+}
+
+func TestWebhookResponse_PreservesOptionalInterfaces(t *testing.T) {
+	minimal := newWebhookResponse(&minimalResponseWriter{header: make(http.Header)})
+	if _, ok := minimal.writer.(http.Flusher); ok {
+		t.Fatal("minimal writer unexpectedly implements http.Flusher")
+	}
+	if _, ok := minimal.writer.(http.Hijacker); ok {
+		t.Fatal("minimal writer unexpectedly implements http.Hijacker")
+	}
+	if _, ok := minimal.writer.(http.Pusher); ok {
+		t.Fatal("minimal writer unexpectedly implements http.Pusher")
+	}
+
+	richRaw := &optionalResponseWriter{minimalResponseWriter: minimalResponseWriter{header: make(http.Header)}}
+	rich := newWebhookResponse(richRaw)
+	if _, ok := rich.writer.(http.Flusher); !ok {
+		t.Fatal("wrapped writer does not preserve http.Flusher")
+	}
+	if _, ok := rich.writer.(http.Hijacker); !ok {
+		t.Fatal("wrapped writer does not preserve http.Hijacker")
+	}
+	if _, ok := rich.writer.(http.Pusher); !ok {
+		t.Fatal("wrapped writer does not preserve http.Pusher")
+	}
+	if _, ok := rich.writer.(io.ReaderFrom); !ok {
+		t.Fatal("wrapped writer does not preserve io.ReaderFrom")
+	}
+	if _, ok := rich.writer.(io.StringWriter); !ok {
+		t.Fatal("wrapped writer does not preserve io.StringWriter")
+	}
+
+	rich.writer.(http.Flusher).Flush()
+	if !rich.isCommitted() || !richRaw.flushed {
+		t.Fatal("Flush did not commit and delegate to the underlying writer")
+	}
+}
+
+type envelopeWebhookHandler struct {
+	botsfw.WebhookHandler
+	get       func(context.Context, *http.Request) (*botsfw.BotContext, []botinput.EntryInputs, error)
+	create    func(botsfw.CreateWebhookContextArgs) (botsfw.WebhookContext, error)
+	responder func(http.ResponseWriter, botsfw.WebhookContext) botsfw.WebhookResponder
+}
+
+func (h envelopeWebhookHandler) GetBotContextAndInputs(
+	ctx context.Context,
+	request *http.Request,
+) (*botsfw.BotContext, []botinput.EntryInputs, error) {
+	return h.get(ctx, request)
+}
+
+func (h envelopeWebhookHandler) CreateWebhookContext(args botsfw.CreateWebhookContextArgs) (botsfw.WebhookContext, error) {
+	return h.create(args)
+}
+
+func (h envelopeWebhookHandler) GetResponder(w http.ResponseWriter, whc botsfw.WebhookContext) botsfw.WebhookResponder {
+	return h.responder(w, whc)
+}
+
+type envelopeRouter struct {
+	botsfw.Router
+	dispatch func(botsfw.WebhookHandler, botsfw.WebhookResponder, botsfw.WebhookContext) error
+}
+
+func (r envelopeRouter) Dispatch(
+	handler botsfw.WebhookHandler,
+	responder botsfw.WebhookResponder,
+	whc botsfw.WebhookContext,
+) error {
+	return r.dispatch(handler, responder, whc)
+}
+
+type envelopeBotProfile struct {
+	botsfw.BotProfile
+	router botsfw.Router
+}
+
+func (p envelopeBotProfile) Router() botsfw.Router {
+	return p.router
+}
+
+type minimalResponseWriter struct {
+	header http.Header
+	status int
+	body   strings.Builder
+}
+
+func (w *minimalResponseWriter) Header() http.Header { return w.header }
+func (w *minimalResponseWriter) WriteHeader(statusCode int) {
+	w.status = statusCode
+}
+func (w *minimalResponseWriter) Write(body []byte) (int, error) {
+	return w.body.Write(body)
+}
+
+type optionalResponseWriter struct {
+	minimalResponseWriter
+	flushed bool
+}
+
+func (w *optionalResponseWriter) Flush() {
+	w.flushed = true
+}
+func (*optionalResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return nil, nil, errors.New("not connected")
+}
+func (*optionalResponseWriter) Push(string, *http.PushOptions) error {
+	return nil
+}
+func (w *optionalResponseWriter) ReadFrom(source io.Reader) (int64, error) {
+	return io.Copy(&w.body, source)
+}
+func (w *optionalResponseWriter) WriteString(body string) (int, error) {
+	return w.body.WriteString(body)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ go 1.25
 require (
 	github.com/bots-go-framework/bots-fw-store v0.12.0
 	github.com/bots-go-framework/bots-go-core v0.2.5
+	github.com/felixge/httpsnoop v1.1.0
 	github.com/stretchr/testify v1.11.1
 	github.com/strongo/analytics v0.2.5
 	github.com/strongo/i18n v0.8.15

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/bots-go-framework/bots-go-core v0.2.5 h1:Uv9zb23yHJY/GnfEF6ocucAmfS12
 github.com/bots-go-framework/bots-go-core v0.2.5/go.mod h1:O/J3Q4HhTpbsbCL87Zhlf1BPtvfVp9UcfBWsc8D8ghw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
+github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=


### PR DESCRIPTION
## What changed

- Track whether the webhook response has committed across writes, headers, flushes, hijacks, string writes, and reader transfers while preserving optional `http.ResponseWriter` interfaces.
- Recover top-level and per-input panics. Before commit, return a fixed generic HTTP 500; after commit, log safely without writing a second response.
- Return fixed generic HTTP errors for parsing, context creation, dispatch, and state preparation failures instead of exposing raw error text.
- Send the sanitized in-chat panic notice through the platform HTTPS channel so it cannot overwrite the HTTP error envelope.
- Bound webhook request bodies at 8 MiB and return 413 for known- and unknown-length oversized payloads.
- Keep panic values, stack traces, and operator footer text in internal logging and analytics only.
- Preserve recovered errors so the durable-inbox layer stacked above this PR can fail its lease.

## Security and reliability invariants

- Panic values, stack traces, source paths, operator footer text, and process errors never reach the HTTP client or chat user.
- A pre-commit panic or processing error cannot fall through as HTTP 200.
- A post-commit failure never appends an error body or attempts a second status write.
- Callback failures use the same pre-commit generic 500 behavior as other inputs.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- Regressions for pre/post-commit panic and error paths, response sanitization, both oversize-body paths, panic recovery hooks, and optional writer-interface preservation

## Dependency

Stacked directly on #93 (`agent/feature-scenario-harness`, head `e0a63d6`). Draft only; do not merge out of order.