### PR TITLE
Add validated feature mount contract

### DIFF
--- a/botsfw/feature_mount.go
+++ b/botsfw/feature_mount.go
@@ -1,0 +1,100 @@
+package botsfw
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bots-go-framework/bots-fw/botinput"
+)
+
+// FeatureMountMode describes how a feature is exposed by its host bot.
+// Dedicated features own the bot surface; embedded features share it with the
+// host and therefore must use an unambiguous namespace and command ownership.
+type FeatureMountMode string
+
+const (
+	FeatureMountDedicated FeatureMountMode = "dedicated"
+	FeatureMountEmbedded  FeatureMountMode = "embedded"
+)
+
+// CommandOwnership declares a command code claimed by a feature for one or
+// more input types. It is metadata only: registration remains compatible with
+// existing Router.RegisterCommands callers.
+type CommandOwnership struct {
+	Code       CommandCode
+	InputTypes []botinput.Type
+}
+
+// FeatureMount is the stable host-to-feature integration contract. Navigator
+// and Capabilities are intentionally strings so individual bot applications can
+// evolve independently while hosts can validate and discover their surfaces.
+type FeatureMount struct {
+	ID           string
+	Mode         FeatureMountMode
+	Namespace    string
+	Navigator    string
+	Capabilities []string
+	Commands     []CommandOwnership
+}
+
+// ValidateFeatureMounts fails before startup if mounted features would make
+// routing ambiguous. This is deliberately separate from Router so existing
+// bots can adopt feature descriptors incrementally.
+func ValidateFeatureMounts(mounts []FeatureMount) error {
+	ids := make(map[string]struct{}, len(mounts))
+	namespaces := make(map[string]struct{}, len(mounts))
+	commands := make(map[featureCommandKey]string)
+	for _, mount := range mounts {
+		if err := validateFeatureMount(mount); err != nil {
+			return err
+		}
+		if _, exists := ids[mount.ID]; exists {
+			return fmt.Errorf("duplicate feature mount ID %q", mount.ID)
+		}
+		ids[mount.ID] = struct{}{}
+		if mount.Namespace != "" {
+			if _, exists := namespaces[mount.Namespace]; exists {
+				return fmt.Errorf("duplicate feature mount namespace %q", mount.Namespace)
+			}
+			namespaces[mount.Namespace] = struct{}{}
+		}
+		for _, ownership := range mount.Commands {
+			for _, inputType := range ownership.InputTypes {
+				key := featureCommandKey{inputType: inputType, code: ownership.Code}
+				if owner, exists := commands[key]; exists {
+					return fmt.Errorf("command %q for input type %q is owned by both features %q and %q", ownership.Code, inputType, owner, mount.ID)
+				}
+				commands[key] = mount.ID
+			}
+		}
+	}
+	return nil
+}
+
+type featureCommandKey struct {
+	inputType botinput.Type
+	code      CommandCode
+}
+
+func validateFeatureMount(mount FeatureMount) error {
+	if strings.TrimSpace(mount.ID) == "" {
+		return fmt.Errorf("feature mount ID is required")
+	}
+	switch mount.Mode {
+	case FeatureMountDedicated, FeatureMountEmbedded:
+	default:
+		return fmt.Errorf("feature %q has invalid mount mode %q", mount.ID, mount.Mode)
+	}
+	if mount.Mode == FeatureMountEmbedded && strings.TrimSpace(mount.Namespace) == "" {
+		return fmt.Errorf("embedded feature %q requires a namespace", mount.ID)
+	}
+	for _, ownership := range mount.Commands {
+		if ownership.Code == "" {
+			return fmt.Errorf("feature %q has command ownership with an empty code", mount.ID)
+		}
+		if len(ownership.InputTypes) == 0 {
+			return fmt.Errorf("feature %q command %q has no input types", mount.ID, ownership.Code)
+		}
+	}
+	return nil
+}

--- a/botsfw/feature_mount.go
+++ b/botsfw/feature_mount.go
@@ -12,6 +12,9 @@ import (
 // host and therefore must use an unambiguous namespace and command ownership.
 type FeatureMountMode string
 
+type CapabilityID string
+type NavigatorID string
+
 const (
 	FeatureMountDedicated FeatureMountMode = "dedicated"
 	FeatureMountEmbedded  FeatureMountMode = "embedded"
@@ -21,8 +24,10 @@ const (
 // more input types. It is metadata only: registration remains compatible with
 // existing Router.RegisterCommands callers.
 type CommandOwnership struct {
-	Code       CommandCode
-	InputTypes []botinput.Type
+	Code               CommandCode
+	Aliases            []CommandCode
+	CallbackNamespaces []string
+	InputTypes         []botinput.Type
 }
 
 // FeatureMount is the stable host-to-feature integration contract. Navigator
@@ -32,10 +37,29 @@ type FeatureMount struct {
 	ID           string
 	Mode         FeatureMountMode
 	Namespace    string
-	Navigator    string
-	Capabilities []string
+	Navigator    NavigatorID
+	Capabilities []CapabilityID
 	Commands     []CommandOwnership
 }
+
+const (
+	ReservedCancelCommand CommandCode = "cancel"
+	ReservedHomeCommand   CommandCode = "home"
+)
+
+// FeatureRegistry is the host startup registry. Its constructor validates
+// mounted features before a router can be exposed, while old hosts may adopt it
+// without changing BotProfile or Router APIs.
+type FeatureRegistry struct{ mounts []FeatureMount }
+
+func NewFeatureRegistry(mounts ...FeatureMount) (*FeatureRegistry, error) {
+	if err := ValidateFeatureMounts(mounts); err != nil {
+		return nil, err
+	}
+	return &FeatureRegistry{mounts: append([]FeatureMount(nil), mounts...)}, nil
+}
+
+func (r *FeatureRegistry) Mounts() []FeatureMount { return append([]FeatureMount(nil), r.mounts...) }
 
 // ValidateFeatureMounts fails before startup if mounted features would make
 // routing ambiguous. This is deliberately separate from Router so existing
@@ -44,6 +68,7 @@ func ValidateFeatureMounts(mounts []FeatureMount) error {
 	ids := make(map[string]struct{}, len(mounts))
 	namespaces := make(map[string]struct{}, len(mounts))
 	commands := make(map[featureCommandKey]string)
+	callbackNamespaces := make(map[string]string)
 	for _, mount := range mounts {
 		if err := validateFeatureMount(mount); err != nil {
 			return err
@@ -59,14 +84,32 @@ func ValidateFeatureMounts(mounts []FeatureMount) error {
 			namespaces[mount.Namespace] = struct{}{}
 		}
 		for _, ownership := range mount.Commands {
-			for _, inputType := range ownership.InputTypes {
-				key := featureCommandKey{inputType: inputType, code: ownership.Code}
-				if owner, exists := commands[key]; exists {
-					return fmt.Errorf("command %q for input type %q is owned by both features %q and %q", ownership.Code, inputType, owner, mount.ID)
+			for _, code := range append([]CommandCode{ownership.Code}, ownership.Aliases...) {
+				if err := registerFeatureCommand(commands, mount.ID, ownership.InputTypes, code); err != nil {
+					return err
 				}
-				commands[key] = mount.ID
+			}
+			for _, namespace := range ownership.CallbackNamespaces {
+				if owner, exists := callbackNamespaces[namespace]; exists {
+					return fmt.Errorf("callback namespace %q is owned by both features %q and %q", namespace, owner, mount.ID)
+				}
+				callbackNamespaces[namespace] = mount.ID
 			}
 		}
+	}
+	return nil
+}
+
+func registerFeatureCommand(commands map[featureCommandKey]string, mountID string, inputTypes []botinput.Type, code CommandCode) error {
+	if code == ReservedCancelCommand || code == ReservedHomeCommand {
+		return fmt.Errorf("feature %q cannot claim reserved host command %q", mountID, code)
+	}
+	for _, inputType := range inputTypes {
+		key := featureCommandKey{inputType: inputType, code: code}
+		if owner, exists := commands[key]; exists {
+			return fmt.Errorf("command %q for input type %q is owned by both features %q and %q", code, inputType, owner, mountID)
+		}
+		commands[key] = mountID
 	}
 	return nil
 }
@@ -94,6 +137,16 @@ func validateFeatureMount(mount FeatureMount) error {
 		}
 		if len(ownership.InputTypes) == 0 {
 			return fmt.Errorf("feature %q command %q has no input types", mount.ID, ownership.Code)
+		}
+		for _, alias := range ownership.Aliases {
+			if alias == "" {
+				return fmt.Errorf("feature %q command %q has an empty alias", mount.ID, ownership.Code)
+			}
+		}
+		for _, namespace := range ownership.CallbackNamespaces {
+			if strings.TrimSpace(namespace) == "" {
+				return fmt.Errorf("feature %q command %q has an empty callback namespace", mount.ID, ownership.Code)
+			}
 		}
 	}
 	return nil

--- a/botsfw/feature_mount_test.go
+++ b/botsfw/feature_mount_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestValidateFeatureMounts(t *testing.T) {
 	valid := []FeatureMount{
-		{ID: "home", Mode: FeatureMountDedicated, Commands: []CommandOwnership{{Code: "home", InputTypes: []botinput.Type{botinput.TypeText}}}},
-		{ID: "debtus", Mode: FeatureMountEmbedded, Namespace: "debtus", Navigator: "space", Capabilities: []string{"receipts"}, Commands: []CommandOwnership{{Code: "debtus_receipt", InputTypes: []botinput.Type{botinput.TypeCallbackQuery}}}},
+		{ID: "home", Mode: FeatureMountDedicated, Commands: []CommandOwnership{{Code: "dashboard", InputTypes: []botinput.Type{botinput.TypeText}}}},
+		{ID: "debtus", Mode: FeatureMountEmbedded, Namespace: "debtus", Navigator: "space", Capabilities: []CapabilityID{"receipts"}, Commands: []CommandOwnership{{Code: "debtus_receipt", InputTypes: []botinput.Type{botinput.TypeCallbackQuery}}}},
 	}
 	if err := ValidateFeatureMounts(valid); err != nil {
 		t.Fatalf("valid mounts: %v", err)

--- a/botsfw/feature_mount_test.go
+++ b/botsfw/feature_mount_test.go
@@ -1,0 +1,47 @@
+package botsfw
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bots-go-framework/bots-fw/botinput"
+)
+
+func TestValidateFeatureMounts(t *testing.T) {
+	valid := []FeatureMount{
+		{ID: "home", Mode: FeatureMountDedicated, Commands: []CommandOwnership{{Code: "home", InputTypes: []botinput.Type{botinput.TypeText}}}},
+		{ID: "debtus", Mode: FeatureMountEmbedded, Namespace: "debtus", Navigator: "space", Capabilities: []string{"receipts"}, Commands: []CommandOwnership{{Code: "debtus_receipt", InputTypes: []botinput.Type{botinput.TypeCallbackQuery}}}},
+	}
+	if err := ValidateFeatureMounts(valid); err != nil {
+		t.Fatalf("valid mounts: %v", err)
+	}
+
+	for name, mounts := range map[string][]FeatureMount{
+		"duplicate ID": {
+			valid[0], {ID: "home", Mode: FeatureMountDedicated},
+		},
+		"embedded namespace required": {
+			{ID: "debtus", Mode: FeatureMountEmbedded},
+		},
+		"duplicate command": {
+			{ID: "one", Mode: FeatureMountDedicated, Commands: []CommandOwnership{{Code: "open", InputTypes: []botinput.Type{botinput.TypeText}}}},
+			{ID: "two", Mode: FeatureMountEmbedded, Namespace: "two", Commands: []CommandOwnership{{Code: "open", InputTypes: []botinput.Type{botinput.TypeText}}}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := ValidateFeatureMounts(mounts); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestValidateFeatureMountsErrorsNameTheConflict(t *testing.T) {
+	err := ValidateFeatureMounts([]FeatureMount{
+		{ID: "one", Mode: FeatureMountEmbedded, Namespace: "shared"},
+		{ID: "two", Mode: FeatureMountEmbedded, Namespace: "shared"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "shared") {
+		t.Fatalf("expected namespace conflict, got %v", err)
+	}
+}


### PR DESCRIPTION
## What changed

- Add a reusable `FeatureMount` descriptor for dedicated and embedded bot features.
- Use typed feature, capability, and navigator identifiers with explicit command ownership.
- Add startup `FeatureRegistry` validation for duplicate feature IDs, namespaces, aliases, callback namespaces, command/input pairs, and reserved host commands.
- Reserve universal host exits such as `/cancel` and Home from embedded feature ownership.
- Keep current router/profile registration source-compatible so bots can adopt mounts incrementally.

## Why

Hosted and embedded features currently rely on naming conventions and registration order. The host needs an explicit contract for what a feature owns and a fail-fast registry for ambiguous routing.

## Validation

- Focused `go test ./botsfw`
- Collision regressions name both owners and cover reserved host commands.

## Stack

This is the foundation for downstream presentation-policy, typed conversation-state, and dedicated/embedded scenario-harness PRs.