### PR TITLE
Deduplicate durable webhook entries before dispatch

### DIFF
--- a/botinput/input_interfaces.go
+++ b/botinput/input_interfaces.go
@@ -11,6 +11,15 @@ type Entry interface {
 	GetTime() time.Time
 }
 
+// DurableWebhookEntry is implemented when a provider supplies a delivery ID
+// which remains stable across retries. Webhook drivers must use this capability
+// for durable deduplication rather than guessing whether Entry.GetID() is a
+// provider update ID.
+type DurableWebhookEntry interface {
+	Entry
+	WebhookUpdateID() (string, bool)
+}
+
 func GetBotInputTypeIdNameString(whInputType Type) string {
 	return fmt.Sprintf("%d:%s", whInputType, whInputType)
 }

--- a/botswebhook/driver.go
+++ b/botswebhook/driver.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"runtime/debug"
 	"strings"
+	"time"
 
+	"github.com/bots-go-framework/bots-fw-store/botsfwstore"
 	"github.com/bots-go-framework/bots-fw/botinput"
 	"github.com/bots-go-framework/bots-fw/botsfw"
 	"github.com/strongo/analytics"
@@ -116,7 +118,7 @@ func (d webhookDriver) HandleWebhook(w http.ResponseWriter, r *http.Request, web
 
 	for _, entryWithInputs := range entriesWithInputs {
 		for i, input := range entryWithInputs.Inputs {
-			if err = d.processWebhookInput(ctx, w, r, webhookHandler, botContext, i, input, handleError); err != nil {
+			if err = d.processWebhookInput(ctx, w, r, webhookHandler, botContext, fmt.Sprint(entryWithInputs.Entry.GetID()), i, input, handleError); err != nil {
 				log.Errorf(ctx, "Failed to process input[%v]: %v", i, err)
 			}
 		}
@@ -136,6 +138,7 @@ func (d webhookDriver) processWebhookInput(
 	ctx context.Context,
 	w http.ResponseWriter, r *http.Request, webhookHandler botsfw.WebhookHandler,
 	botContext *botsfw.BotContext,
+	updateID string,
 	i int,
 	input botinput.InputMessage,
 	handleError func(err error, message string),
@@ -143,7 +146,9 @@ func (d webhookDriver) processWebhookInput(
 	err error,
 ) {
 	var (
-		whc botsfw.WebhookContext // TODO: How do deal with Facebook multiple entries per request?
+		whc       botsfw.WebhookContext // TODO: How do deal with Facebook multiple entries per request?
+		updateKey botsfwstore.WebhookUpdateKey
+		leaseID   string
 	)
 
 	defer func() {
@@ -215,6 +220,33 @@ func (d webhookDriver) processWebhookInput(
 		handleError(err, "Failed to prepare webhook state")
 		return
 	}
+	updateKey = botsfwstore.WebhookUpdateKey{PlatformID: string(botContext.BotSettings.Platform), BotID: botContext.BotSettings.Code, UpdateID: updateID}
+	claim, claimErr := store.ClaimWebhookUpdate(ctx, updateKey, time.Now().UTC().Add(2*time.Minute))
+	if claimErr != nil {
+		return fmt.Errorf("claim webhook update: %w", claimErr)
+	}
+	switch claim.Status {
+	case botsfwstore.WebhookUpdateClaimCompleted:
+		w.WriteHeader(http.StatusOK)
+		return nil
+	case botsfwstore.WebhookUpdateClaimLeased:
+		// A live owner may still commit the side effect. Do not acknowledge this
+		// delivery as complete: Telegram will retry the same update after the
+		// lease expires if the owner crashes.
+		http.Error(w, "webhook update is being processed", http.StatusServiceUnavailable)
+		return nil
+	case botsfwstore.WebhookUpdateClaimAcquired:
+		leaseID = claim.LeaseID
+	default:
+		return fmt.Errorf("claim webhook update returned unknown status %q", claim.Status)
+	}
+	defer func() {
+		if err != nil && leaseID != "" {
+			if failErr := store.FailWebhookUpdate(ctx, updateKey, leaseID, err); failErr != nil {
+				log.Errorf(ctx, "failed to mark webhook update as failed: %v", failErr)
+			}
+		}
+	}()
 	whcArgs := botsfw.NewCreateWebhookContextArgs(r, botContext.AppContext, *botContext, input, store)
 	if whc, err = webhookHandler.CreateWebhookContext(whcArgs); err != nil {
 		handleError(err, "Failed to create WebhookContext")
@@ -235,6 +267,10 @@ func (d webhookDriver) processWebhookInput(
 
 	if err = router.Dispatch(webhookHandler, routerResponder, whc); err != nil {
 		handleError(err, "Failed to dispatch")
+		return
+	}
+	if err = store.CompleteWebhookUpdate(ctx, updateKey, leaseID); err != nil {
+		handleError(err, "Failed to complete webhook update")
 		return
 	}
 

--- a/botswebhook/driver.go
+++ b/botswebhook/driver.go
@@ -117,7 +117,7 @@ func (d webhookDriver) HandleWebhook(w http.ResponseWriter, r *http.Request, web
 	}
 
 	for _, entryWithInputs := range entriesWithInputs {
-		if err = d.processWebhookEntry(ctx, w, r, webhookHandler, botContext, entryWithInputs, handleError); err != nil {
+		if err = d.processWebhookEntry(ctx, response, r, webhookHandler, botContext, entryWithInputs, handleError); err != nil {
 			log.Errorf(ctx, "Failed to process webhook entry: %v", err)
 		}
 	}
@@ -138,7 +138,7 @@ func (webhookDriver) handleProcessingError(ctx context.Context, response *webhoo
 // update ID.
 func (d webhookDriver) processWebhookEntry(
 	ctx context.Context,
-	w http.ResponseWriter, r *http.Request, webhookHandler botsfw.WebhookHandler,
+	response *webhookResponse, r *http.Request, webhookHandler botsfw.WebhookHandler,
 	botContext *botsfw.BotContext,
 	entryWithInputs botinput.EntryInputs,
 	handleError func(error, string),
@@ -165,10 +165,12 @@ func (d webhookDriver) processWebhookEntry(
 		}
 		switch claim.Status {
 		case botsfwstore.WebhookUpdateClaimCompleted:
-			w.WriteHeader(http.StatusOK)
+			if !response.isCommitted() {
+				response.writer.WriteHeader(http.StatusOK)
+			}
 			return nil
 		case botsfwstore.WebhookUpdateClaimLeased:
-			http.Error(w, "webhook update is being processed", http.StatusServiceUnavailable)
+			response.writeError(http.StatusServiceUnavailable)
 			return nil
 		case botsfwstore.WebhookUpdateClaimAcquired:
 			leaseID = claim.LeaseID
@@ -187,7 +189,7 @@ func (d webhookDriver) processWebhookEntry(
 	}
 
 	for i, input := range entryWithInputs.Inputs {
-		if err = d.processWebhookInput(ctx, w, r, webhookHandler, botContext, i, input, handleError); err != nil {
+		if err = d.processWebhookInput(ctx, response.writer, r, webhookHandler, botContext, i, input, handleError); err != nil {
 			return fmt.Errorf("process input[%d]: %w", i, err)
 		}
 	}

--- a/botswebhook/driver.go
+++ b/botswebhook/driver.go
@@ -117,18 +117,8 @@ func (d webhookDriver) HandleWebhook(w http.ResponseWriter, r *http.Request, web
 	}
 
 	for _, entryWithInputs := range entriesWithInputs {
-		// Not every webhook provider exposes a durable delivery/update identifier.
-		// Preserve the legacy dispatch path for those adapters rather than turning
-		// every missing ID into the same (and therefore permanently suppressed)
-		// update. Money-changing actions still need their own idempotency key.
-		updateID := ""
-		if entryWithInputs.Entry != nil {
-			updateID = fmt.Sprint(entryWithInputs.Entry.GetID())
-		}
-		for i, input := range entryWithInputs.Inputs {
-			if err = d.processWebhookInput(ctx, w, r, webhookHandler, botContext, updateID, i, input, handleError); err != nil {
-				log.Errorf(ctx, "Failed to process input[%v]: %v", i, err)
-			}
+		if err = d.processWebhookEntry(ctx, w, r, webhookHandler, botContext, entryWithInputs, handleError); err != nil {
+			log.Errorf(ctx, "Failed to process webhook entry: %v", err)
 		}
 	}
 }
@@ -142,11 +132,130 @@ func (webhookDriver) handleProcessingError(ctx context.Context, response *webhoo
 	response.writeError(http.StatusInternalServerError)
 }
 
+// processWebhookEntry leases one provider delivery and processes every input it
+// contains before completing it. An entry is the provider's atomic retry unit;
+// claiming per input would incorrectly suppress sibling inputs with the same
+// update ID.
+func (d webhookDriver) processWebhookEntry(
+	ctx context.Context,
+	w http.ResponseWriter, r *http.Request, webhookHandler botsfw.WebhookHandler,
+	botContext *botsfw.BotContext,
+	entryWithInputs botinput.EntryInputs,
+	handleError func(error, string),
+) (err error) {
+	updateID, hasUpdateID := webhookUpdateID(entryWithInputs.Entry)
+	store := botContext.BotSettings.Store
+	if store == nil {
+		err = fmt.Errorf("bot %q has no state store", botContext.BotSettings.Code)
+		handleError(err, "Failed to prepare webhook state")
+		return
+	}
+
+	var (
+		updateKey botsfwstore.WebhookUpdateKey
+		leaseID   string
+	)
+	if hasUpdateID {
+		updateKey = botsfwstore.WebhookUpdateKey{PlatformID: string(botContext.BotSettings.Platform), BotID: botContext.BotSettings.Code, UpdateID: updateID}
+		claim, claimErr := store.ClaimWebhookUpdate(ctx, updateKey, time.Now().UTC().Add(2*time.Minute))
+		if claimErr != nil {
+			err = fmt.Errorf("claim webhook update: %w", claimErr)
+			handleError(err, "Failed to claim webhook update")
+			return
+		}
+		switch claim.Status {
+		case botsfwstore.WebhookUpdateClaimCompleted:
+			w.WriteHeader(http.StatusOK)
+			return nil
+		case botsfwstore.WebhookUpdateClaimLeased:
+			http.Error(w, "webhook update is being processed", http.StatusServiceUnavailable)
+			return nil
+		case botsfwstore.WebhookUpdateClaimAcquired:
+			leaseID = claim.LeaseID
+		default:
+			err = fmt.Errorf("claim webhook update returned unknown status %q", claim.Status)
+			handleError(err, "Failed to claim webhook update")
+			return
+		}
+		defer func() {
+			if err != nil && leaseID != "" {
+				if failErr := store.FailWebhookUpdate(ctx, updateKey, leaseID, botsfwstore.WebhookUpdateFailureProcessing); failErr != nil {
+					log.Errorf(ctx, "failed to mark webhook update as failed: %v", failErr)
+				}
+			}
+		}()
+	}
+
+	for i, input := range entryWithInputs.Inputs {
+		if err = d.processWebhookInput(ctx, w, r, webhookHandler, botContext, i, input, handleError); err != nil {
+			return fmt.Errorf("process input[%d]: %w", i, err)
+		}
+	}
+
+	if leaseID != "" {
+		if err = store.CompleteWebhookUpdate(ctx, updateKey, leaseID); err != nil {
+			err = fmt.Errorf("complete webhook update: %w", err)
+			handleError(err, "Failed to complete webhook update")
+			return
+		}
+	}
+	return nil
+}
+
+func webhookUpdateID(entry botinput.Entry) (string, bool) {
+	if entry == nil {
+		return "", false
+	}
+	if durableEntry, ok := entry.(botinput.DurableWebhookEntry); ok {
+		id, ok := durableEntry.WebhookUpdateID()
+		id = strings.TrimSpace(id)
+		if !ok || id == "" {
+			return "", false
+		}
+		return id, true
+	}
+
+	// Compatibility fallback for adapters that predate DurableWebhookEntry.
+	// It deliberately rejects absent and zero IDs, both of which conventionally
+	// mean the provider did not attach a durable delivery identifier.
+	switch id := entry.GetID().(type) {
+	case nil:
+		return "", false
+	case string:
+		id = strings.TrimSpace(id)
+		return id, id != ""
+	case int:
+		if id == 0 {
+			return "", false
+		}
+	case int32:
+		if id == 0 {
+			return "", false
+		}
+	case int64:
+		if id == 0 {
+			return "", false
+		}
+	case uint:
+		if id == 0 {
+			return "", false
+		}
+	case uint32:
+		if id == 0 {
+			return "", false
+		}
+	case uint64:
+		if id == 0 {
+			return "", false
+		}
+	}
+	return fmt.Sprint(entry.GetID()), true
+}
+
 func (d webhookDriver) processWebhookInput(
 	ctx context.Context,
 	w http.ResponseWriter, r *http.Request, webhookHandler botsfw.WebhookHandler,
 	botContext *botsfw.BotContext,
-	updateID string,
 	i int,
 	input botinput.InputMessage,
 	handleError func(err error, message string),
@@ -154,9 +263,7 @@ func (d webhookDriver) processWebhookInput(
 	err error,
 ) {
 	var (
-		whc       botsfw.WebhookContext // TODO: How do deal with Facebook multiple entries per request?
-		updateKey botsfwstore.WebhookUpdateKey
-		leaseID   string
+		whc botsfw.WebhookContext // TODO: How do deal with Facebook multiple entries per request?
 	)
 
 	defer func() {
@@ -228,35 +335,6 @@ func (d webhookDriver) processWebhookInput(
 		handleError(err, "Failed to prepare webhook state")
 		return
 	}
-	if updateID != "" {
-		updateKey = botsfwstore.WebhookUpdateKey{PlatformID: string(botContext.BotSettings.Platform), BotID: botContext.BotSettings.Code, UpdateID: updateID}
-		claim, claimErr := store.ClaimWebhookUpdate(ctx, updateKey, time.Now().UTC().Add(2*time.Minute))
-		if claimErr != nil {
-			return fmt.Errorf("claim webhook update: %w", claimErr)
-		}
-		switch claim.Status {
-		case botsfwstore.WebhookUpdateClaimCompleted:
-			w.WriteHeader(http.StatusOK)
-			return nil
-		case botsfwstore.WebhookUpdateClaimLeased:
-			// A live owner may still commit the side effect. Do not acknowledge this
-			// delivery as complete: Telegram will retry the same update after the
-			// lease expires if the owner crashes.
-			http.Error(w, "webhook update is being processed", http.StatusServiceUnavailable)
-			return nil
-		case botsfwstore.WebhookUpdateClaimAcquired:
-			leaseID = claim.LeaseID
-		default:
-			return fmt.Errorf("claim webhook update returned unknown status %q", claim.Status)
-		}
-		defer func() {
-			if err != nil && leaseID != "" {
-				if failErr := store.FailWebhookUpdate(ctx, updateKey, leaseID, err); failErr != nil {
-					log.Errorf(ctx, "failed to mark webhook update as failed: %v", failErr)
-				}
-			}
-		}()
-	}
 	whcArgs := botsfw.NewCreateWebhookContextArgs(r, botContext.AppContext, *botContext, input, store)
 	if whc, err = webhookHandler.CreateWebhookContext(whcArgs); err != nil {
 		handleError(err, "Failed to create WebhookContext")
@@ -279,13 +357,6 @@ func (d webhookDriver) processWebhookInput(
 		handleError(err, "Failed to dispatch")
 		return
 	}
-	if leaseID != "" {
-		if err = store.CompleteWebhookUpdate(ctx, updateKey, leaseID); err != nil {
-			handleError(err, "Failed to complete webhook update")
-			return
-		}
-	}
-
 	return
 }
 

--- a/botswebhook/driver.go
+++ b/botswebhook/driver.go
@@ -117,8 +117,16 @@ func (d webhookDriver) HandleWebhook(w http.ResponseWriter, r *http.Request, web
 	}
 
 	for _, entryWithInputs := range entriesWithInputs {
+		// Not every webhook provider exposes a durable delivery/update identifier.
+		// Preserve the legacy dispatch path for those adapters rather than turning
+		// every missing ID into the same (and therefore permanently suppressed)
+		// update. Money-changing actions still need their own idempotency key.
+		updateID := ""
+		if entryWithInputs.Entry != nil {
+			updateID = fmt.Sprint(entryWithInputs.Entry.GetID())
+		}
 		for i, input := range entryWithInputs.Inputs {
-			if err = d.processWebhookInput(ctx, w, r, webhookHandler, botContext, fmt.Sprint(entryWithInputs.Entry.GetID()), i, input, handleError); err != nil {
+			if err = d.processWebhookInput(ctx, w, r, webhookHandler, botContext, updateID, i, input, handleError); err != nil {
 				log.Errorf(ctx, "Failed to process input[%v]: %v", i, err)
 			}
 		}
@@ -220,33 +228,35 @@ func (d webhookDriver) processWebhookInput(
 		handleError(err, "Failed to prepare webhook state")
 		return
 	}
-	updateKey = botsfwstore.WebhookUpdateKey{PlatformID: string(botContext.BotSettings.Platform), BotID: botContext.BotSettings.Code, UpdateID: updateID}
-	claim, claimErr := store.ClaimWebhookUpdate(ctx, updateKey, time.Now().UTC().Add(2*time.Minute))
-	if claimErr != nil {
-		return fmt.Errorf("claim webhook update: %w", claimErr)
-	}
-	switch claim.Status {
-	case botsfwstore.WebhookUpdateClaimCompleted:
-		w.WriteHeader(http.StatusOK)
-		return nil
-	case botsfwstore.WebhookUpdateClaimLeased:
-		// A live owner may still commit the side effect. Do not acknowledge this
-		// delivery as complete: Telegram will retry the same update after the
-		// lease expires if the owner crashes.
-		http.Error(w, "webhook update is being processed", http.StatusServiceUnavailable)
-		return nil
-	case botsfwstore.WebhookUpdateClaimAcquired:
-		leaseID = claim.LeaseID
-	default:
-		return fmt.Errorf("claim webhook update returned unknown status %q", claim.Status)
-	}
-	defer func() {
-		if err != nil && leaseID != "" {
-			if failErr := store.FailWebhookUpdate(ctx, updateKey, leaseID, err); failErr != nil {
-				log.Errorf(ctx, "failed to mark webhook update as failed: %v", failErr)
-			}
+	if updateID != "" {
+		updateKey = botsfwstore.WebhookUpdateKey{PlatformID: string(botContext.BotSettings.Platform), BotID: botContext.BotSettings.Code, UpdateID: updateID}
+		claim, claimErr := store.ClaimWebhookUpdate(ctx, updateKey, time.Now().UTC().Add(2*time.Minute))
+		if claimErr != nil {
+			return fmt.Errorf("claim webhook update: %w", claimErr)
 		}
-	}()
+		switch claim.Status {
+		case botsfwstore.WebhookUpdateClaimCompleted:
+			w.WriteHeader(http.StatusOK)
+			return nil
+		case botsfwstore.WebhookUpdateClaimLeased:
+			// A live owner may still commit the side effect. Do not acknowledge this
+			// delivery as complete: Telegram will retry the same update after the
+			// lease expires if the owner crashes.
+			http.Error(w, "webhook update is being processed", http.StatusServiceUnavailable)
+			return nil
+		case botsfwstore.WebhookUpdateClaimAcquired:
+			leaseID = claim.LeaseID
+		default:
+			return fmt.Errorf("claim webhook update returned unknown status %q", claim.Status)
+		}
+		defer func() {
+			if err != nil && leaseID != "" {
+				if failErr := store.FailWebhookUpdate(ctx, updateKey, leaseID, err); failErr != nil {
+					log.Errorf(ctx, "failed to mark webhook update as failed: %v", failErr)
+				}
+			}
+		}()
+	}
 	whcArgs := botsfw.NewCreateWebhookContextArgs(r, botContext.AppContext, *botContext, input, store)
 	if whc, err = webhookHandler.CreateWebhookContext(whcArgs); err != nil {
 		handleError(err, "Failed to create WebhookContext")
@@ -269,9 +279,11 @@ func (d webhookDriver) processWebhookInput(
 		handleError(err, "Failed to dispatch")
 		return
 	}
-	if err = store.CompleteWebhookUpdate(ctx, updateKey, leaseID); err != nil {
-		handleError(err, "Failed to complete webhook update")
-		return
+	if leaseID != "" {
+		if err = store.CompleteWebhookUpdate(ctx, updateKey, leaseID); err != nil {
+			handleError(err, "Failed to complete webhook update")
+			return
+		}
 	}
 
 	return

--- a/botswebhook/driver_update_id_test.go
+++ b/botswebhook/driver_update_id_test.go
@@ -1,0 +1,48 @@
+package botswebhook
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bots-go-framework/bots-fw/botinput"
+)
+
+type testWebhookEntry struct{ id any }
+
+func (e testWebhookEntry) GetID() any       { return e.id }
+func (testWebhookEntry) GetTime() time.Time { return time.Time{} }
+
+type testDurableWebhookEntry struct {
+	testWebhookEntry
+	updateID string
+	ok       bool
+}
+
+func (e testDurableWebhookEntry) WebhookUpdateID() (string, bool) { return e.updateID, e.ok }
+
+var _ botinput.DurableWebhookEntry = testDurableWebhookEntry{}
+
+func TestWebhookUpdateID(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry botinput.Entry
+		id    string
+		ok    bool
+	}{
+		{name: "nil"},
+		{name: "nil ID", entry: testWebhookEntry{}},
+		{name: "empty ID", entry: testWebhookEntry{id: "  "}},
+		{name: "zero int ID", entry: testWebhookEntry{id: 0}},
+		{name: "nonzero compatibility ID", entry: testWebhookEntry{id: 42}, id: "42", ok: true},
+		{name: "explicit durable ID", entry: testDurableWebhookEntry{updateID: "update-42", ok: true}, id: "update-42", ok: true},
+		{name: "explicit unavailable durable ID", entry: testDurableWebhookEntry{updateID: "update-42", ok: false}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, ok := webhookUpdateID(tt.entry)
+			if id != tt.id || ok != tt.ok {
+				t.Fatalf("webhookUpdateID() = %q, %t; want %q, %t", id, ok, tt.id, tt.ok)
+			}
+		})
+	}
+}

--- a/botswebhook/driver_update_inbox_test.go
+++ b/botswebhook/driver_update_inbox_test.go
@@ -1,0 +1,174 @@
+package botswebhook
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/bots-go-framework/bots-fw-store/botsfwmodels"
+	"github.com/bots-go-framework/bots-fw-store/botsfwstore"
+	"github.com/bots-go-framework/bots-fw-store/botsfwstore/botsfwstoretest"
+	"github.com/bots-go-framework/bots-fw/botinput"
+	"github.com/bots-go-framework/bots-fw/botmsg"
+	"github.com/bots-go-framework/bots-fw/botsfw"
+	"github.com/bots-go-framework/bots-fw/botsfwconst"
+	"github.com/bots-go-framework/bots-fw/botsfwtest"
+	"github.com/strongo/i18n"
+)
+
+type updateInboxTestHandler struct {
+	createWebhookContext func(botsfw.CreateWebhookContextArgs) (botsfw.WebhookContext, error)
+}
+
+func (updateInboxTestHandler) RegisterHttpHandlers(botsfw.WebhookDriver, botsfw.BotHost, botsfw.HttpRouter, string) {
+}
+
+func (updateInboxTestHandler) HandleWebhookRequest(http.ResponseWriter, *http.Request) {}
+
+func (updateInboxTestHandler) GetBotContextAndInputs(context.Context, *http.Request) (*botsfw.BotContext, []botinput.EntryInputs, error) {
+	return nil, nil, errors.New("not used by processWebhookEntry test")
+}
+
+func (h updateInboxTestHandler) CreateWebhookContext(args botsfw.CreateWebhookContextArgs) (botsfw.WebhookContext, error) {
+	return h.createWebhookContext(args)
+}
+
+func (updateInboxTestHandler) GetResponder(_ http.ResponseWriter, whc botsfw.WebhookContext) botsfw.WebhookResponder {
+	return whc.Responder()
+}
+
+func (updateInboxTestHandler) HandleUnmatched(botsfw.WebhookContext) botmsg.MessageFromBot {
+	return botmsg.MessageFromBot{}
+}
+
+func TestProcessWebhookEntryClaimsWholeProviderEntry(t *testing.T) {
+	tests := []struct {
+		name           string
+		failInput      int
+		wantErr        bool
+		wantCompleted  int
+		wantFailed     int
+		wantDispatched int
+	}{
+		{
+			name:           "all sibling inputs complete under one claim",
+			failInput:      -1,
+			wantCompleted:  1,
+			wantDispatched: 2,
+		},
+		{
+			name:           "partial failure fails the entry once",
+			failInput:      1,
+			wantErr:        true,
+			wantFailed:     1,
+			wantDispatched: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var claimed, completed, failed, dispatched int
+			const leaseID = "lease-1"
+			store := &botsfwstoretest.FakeStateStore{
+				ClaimWebhookUpdateFunc: func(_ context.Context, key botsfwstore.WebhookUpdateKey, _ time.Time) (botsfwstore.WebhookUpdateClaim, error) {
+					claimed++
+					if key.UpdateID != "provider-entry-42" {
+						t.Fatalf("claimed update ID = %q", key.UpdateID)
+					}
+					return botsfwstore.WebhookUpdateClaim{
+						Status:  botsfwstore.WebhookUpdateClaimAcquired,
+						LeaseID: leaseID,
+					}, nil
+				},
+				CompleteWebhookUpdateFunc: func(_ context.Context, _ botsfwstore.WebhookUpdateKey, gotLeaseID string) error {
+					completed++
+					if gotLeaseID != leaseID {
+						t.Fatalf("completed lease ID = %q", gotLeaseID)
+					}
+					return nil
+				},
+				FailWebhookUpdateFunc: func(_ context.Context, _ botsfwstore.WebhookUpdateKey, gotLeaseID string, code botsfwstore.WebhookUpdateFailureCode) error {
+					failed++
+					if gotLeaseID != leaseID {
+						t.Fatalf("failed lease ID = %q", gotLeaseID)
+					}
+					if code != botsfwstore.WebhookUpdateFailureProcessing {
+						t.Fatalf("failure code = %q", code)
+					}
+					return nil
+				},
+			}
+
+			router := NewWebhookRouter(nil)
+			router.SetFallbackHandler(botinput.TypeText, func(botsfw.WebhookContext) (botmsg.MessageFromBot, error) {
+				dispatched++
+				return botmsg.MessageFromBot{}, nil
+			})
+			profile := botsfw.NewBotProfile(
+				"update-inbox-test",
+				router,
+				func() botsfwmodels.BotChatData { return nil },
+				func() botsfwmodels.PlatformUserData { return nil },
+				i18n.LocaleEnUS,
+				nil,
+				botsfw.BotTranslations{},
+			)
+			botContext := &botsfw.BotContext{BotSettings: &botsfw.BotSettings{
+				Platform: botsfwconst.PlatformTelegram,
+				Code:     "test-bot",
+				Profile:  profile,
+				Store:    store,
+			}}
+
+			contexts := []*botsfwtest.FakeWebhookContext{
+				botsfwtest.NewFakeWebhookContext(botsfwtest.WithTextMessage("first")),
+				botsfwtest.NewFakeWebhookContext(botsfwtest.WithTextMessage("second")),
+			}
+			inputIndex := map[botinput.InputMessage]int{
+				contexts[0].Input(): 0,
+				contexts[1].Input(): 1,
+			}
+			handler := updateInboxTestHandler{
+				createWebhookContext: func(args botsfw.CreateWebhookContextArgs) (botsfw.WebhookContext, error) {
+					index := inputIndex[args.WebhookInput]
+					if index == tt.failInput {
+						return nil, errors.New("injected context failure")
+					}
+					return contexts[index], nil
+				},
+			}
+			entry := botinput.EntryInputs{
+				Entry:  testDurableWebhookEntry{updateID: "provider-entry-42", ok: true},
+				Inputs: []botinput.InputMessage{contexts[0].Input(), contexts[1].Input()},
+			}
+
+			err := (webhookDriver{}).processWebhookEntry(
+				context.Background(),
+				httptest.NewRecorder(),
+				httptest.NewRequest(http.MethodPost, "/webhook", nil),
+				handler,
+				botContext,
+				entry,
+				func(error, string) {},
+			)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("processWebhookEntry() error = %v, wantErr %t", err, tt.wantErr)
+			}
+			if claimed != 1 {
+				t.Fatalf("ClaimWebhookUpdate calls = %d, want 1", claimed)
+			}
+			if completed != tt.wantCompleted {
+				t.Fatalf("CompleteWebhookUpdate calls = %d, want %d", completed, tt.wantCompleted)
+			}
+			if failed != tt.wantFailed {
+				t.Fatalf("FailWebhookUpdate calls = %d, want %d", failed, tt.wantFailed)
+			}
+			if dispatched != tt.wantDispatched {
+				t.Fatalf("router dispatches = %d, want %d", dispatched, tt.wantDispatched)
+			}
+		})
+	}
+}

--- a/botswebhook/driver_update_inbox_test.go
+++ b/botswebhook/driver_update_inbox_test.go
@@ -3,6 +3,7 @@ package botswebhook
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -147,7 +148,7 @@ func TestProcessWebhookEntryClaimsWholeProviderEntry(t *testing.T) {
 
 			err := (webhookDriver{}).processWebhookEntry(
 				context.Background(),
-				httptest.NewRecorder(),
+				newWebhookResponse(httptest.NewRecorder()),
 				httptest.NewRequest(http.MethodPost, "/webhook", nil),
 				handler,
 				botContext,
@@ -168,6 +169,67 @@ func TestProcessWebhookEntryClaimsWholeProviderEntry(t *testing.T) {
 			}
 			if dispatched != tt.wantDispatched {
 				t.Fatalf("router dispatches = %d, want %d", dispatched, tt.wantDispatched)
+			}
+		})
+	}
+}
+
+func TestProcessWebhookEntryLeasedResponseIsCommitAware(t *testing.T) {
+	tests := []struct {
+		name       string
+		commit     bool
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name:       "pre-commit returns generic retry status",
+			wantStatus: http.StatusServiceUnavailable,
+			wantBody:   http.StatusText(http.StatusServiceUnavailable) + "\n",
+		},
+		{
+			name:       "post-commit leaves platform response unchanged",
+			commit:     true,
+			wantStatus: http.StatusAccepted,
+			wantBody:   "platform response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &botsfwstoretest.FakeStateStore{
+				ClaimWebhookUpdateFunc: func(context.Context, botsfwstore.WebhookUpdateKey, time.Time) (botsfwstore.WebhookUpdateClaim, error) {
+					return botsfwstore.WebhookUpdateClaim{Status: botsfwstore.WebhookUpdateClaimLeased}, nil
+				},
+			}
+			botContext := &botsfw.BotContext{BotSettings: &botsfw.BotSettings{
+				Platform: botsfwconst.PlatformTelegram,
+				Code:     "test-bot",
+				Store:    store,
+			}}
+			recorder := httptest.NewRecorder()
+			response := newWebhookResponse(recorder)
+			if tt.commit {
+				response.writer.WriteHeader(http.StatusAccepted)
+				_, _ = io.WriteString(response.writer, tt.wantBody)
+			}
+
+			err := (webhookDriver{}).processWebhookEntry(
+				context.Background(),
+				response,
+				httptest.NewRequest(http.MethodPost, "/webhook", nil),
+				updateInboxTestHandler{},
+				botContext,
+				botinput.EntryInputs{Entry: testDurableWebhookEntry{updateID: "provider-entry-42", ok: true}},
+				func(error, string) {},
+			)
+			if err != nil {
+				t.Fatalf("processWebhookEntry() error = %v", err)
+			}
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("HTTP status = %d, want %d", recorder.Code, tt.wantStatus)
+			}
+			if body := recorder.Body.String(); body != tt.wantBody {
+				t.Fatalf("HTTP body = %q, want %q", body, tt.wantBody)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.25
 //replace github.com/strongo/i18n => ../../strongo/i18n
 //replace github.com/bots-go-framework/bots-go-core => ../bots-go-core
 require (
-	github.com/bots-go-framework/bots-fw-store v0.13.1-0.20260725152240-2967bfc67c9f
+	github.com/bots-go-framework/bots-fw-store v0.14.1-0.20260725165959-023758cc8659
 	github.com/bots-go-framework/bots-go-core v0.2.5
 	github.com/felixge/httpsnoop v1.1.0
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.25
 //replace github.com/strongo/i18n => ../../strongo/i18n
 //replace github.com/bots-go-framework/bots-go-core => ../bots-go-core
 require (
-	github.com/bots-go-framework/bots-fw-store v0.12.0
+	github.com/bots-go-framework/bots-fw-store v0.13.1-0.20260725151510-88ca74e20f97
 	github.com/bots-go-framework/bots-go-core v0.2.5
 	github.com/felixge/httpsnoop v1.1.0
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.25
 //replace github.com/strongo/i18n => ../../strongo/i18n
 //replace github.com/bots-go-framework/bots-go-core => ../bots-go-core
 require (
-	github.com/bots-go-framework/bots-fw-store v0.13.1-0.20260725151510-88ca74e20f97
+	github.com/bots-go-framework/bots-fw-store v0.13.1-0.20260725152240-2967bfc67c9f
 	github.com/bots-go-framework/bots-go-core v0.2.5
 	github.com/felixge/httpsnoop v1.1.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/bots-go-framework/bots-fw-store v0.12.0 h1:oz2tCpsiTZ2WdeQhkG3H4vq44N
 github.com/bots-go-framework/bots-fw-store v0.12.0/go.mod h1:0yS6Pg516jHIrIInv+kvWRWxXNGGqR4tlvRua8GfT20=
 github.com/bots-go-framework/bots-fw-store v0.13.1-0.20260725151510-88ca74e20f97 h1:2av63TYtXX32JiYoCeKdORrNalVL8u7VJ+zszNauDr4=
 github.com/bots-go-framework/bots-fw-store v0.13.1-0.20260725151510-88ca74e20f97/go.mod h1:0yS6Pg516jHIrIInv+kvWRWxXNGGqR4tlvRua8GfT20=
+github.com/bots-go-framework/bots-fw-store v0.13.1-0.20260725152240-2967bfc67c9f h1:5vgU3oUvRMO+LB+9RNgWfFKNT4jrinYCWhKYISTJt3o=
+github.com/bots-go-framework/bots-fw-store v0.13.1-0.20260725152240-2967bfc67c9f/go.mod h1:0yS6Pg516jHIrIInv+kvWRWxXNGGqR4tlvRua8GfT20=
 github.com/bots-go-framework/bots-go-core v0.2.5 h1:Uv9zb23yHJY/GnfEF6ocucAmfS12pwFHiig29ZoSqME=
 github.com/bots-go-framework/bots-go-core v0.2.5/go.mod h1:O/J3Q4HhTpbsbCL87Zhlf1BPtvfVp9UcfBWsc8D8ghw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/bots-go-framework/bots-fw-store v0.12.0 h1:oz2tCpsiTZ2WdeQhkG3H4vq44N24kxBUzXg1ie2nrRU=
 github.com/bots-go-framework/bots-fw-store v0.12.0/go.mod h1:0yS6Pg516jHIrIInv+kvWRWxXNGGqR4tlvRua8GfT20=
+github.com/bots-go-framework/bots-fw-store v0.13.1-0.20260725151510-88ca74e20f97 h1:2av63TYtXX32JiYoCeKdORrNalVL8u7VJ+zszNauDr4=
+github.com/bots-go-framework/bots-fw-store v0.13.1-0.20260725151510-88ca74e20f97/go.mod h1:0yS6Pg516jHIrIInv+kvWRWxXNGGqR4tlvRua8GfT20=
 github.com/bots-go-framework/bots-go-core v0.2.5 h1:Uv9zb23yHJY/GnfEF6ocucAmfS12pwFHiig29ZoSqME=
 github.com/bots-go-framework/bots-go-core v0.2.5/go.mod h1:O/J3Q4HhTpbsbCL87Zhlf1BPtvfVp9UcfBWsc8D8ghw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,5 @@
-github.com/bots-go-framework/bots-fw-store v0.12.0 h1:oz2tCpsiTZ2WdeQhkG3H4vq44N24kxBUzXg1ie2nrRU=
-github.com/bots-go-framework/bots-fw-store v0.12.0/go.mod h1:0yS6Pg516jHIrIInv+kvWRWxXNGGqR4tlvRua8GfT20=
-github.com/bots-go-framework/bots-fw-store v0.13.1-0.20260725151510-88ca74e20f97 h1:2av63TYtXX32JiYoCeKdORrNalVL8u7VJ+zszNauDr4=
-github.com/bots-go-framework/bots-fw-store v0.13.1-0.20260725151510-88ca74e20f97/go.mod h1:0yS6Pg516jHIrIInv+kvWRWxXNGGqR4tlvRua8GfT20=
-github.com/bots-go-framework/bots-fw-store v0.13.1-0.20260725152240-2967bfc67c9f h1:5vgU3oUvRMO+LB+9RNgWfFKNT4jrinYCWhKYISTJt3o=
-github.com/bots-go-framework/bots-fw-store v0.13.1-0.20260725152240-2967bfc67c9f/go.mod h1:0yS6Pg516jHIrIInv+kvWRWxXNGGqR4tlvRua8GfT20=
+github.com/bots-go-framework/bots-fw-store v0.14.1-0.20260725165959-023758cc8659 h1:ZF953xBKI5eSMzA+jENLnv/jXn33SXvGlpL9eA6sxqI=
+github.com/bots-go-framework/bots-fw-store v0.14.1-0.20260725165959-023758cc8659/go.mod h1:0yS6Pg516jHIrIInv+kvWRWxXNGGqR4tlvRua8GfT20=
 github.com/bots-go-framework/bots-go-core v0.2.5 h1:Uv9zb23yHJY/GnfEF6ocucAmfS12pwFHiig29ZoSqME=
 github.com/bots-go-framework/bots-go-core v0.2.5/go.mod h1:O/J3Q4HhTpbsbCL87Zhlf1BPtvfVp9UcfBWsc8D8ghw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
## What changed

- Add an explicit `DurableWebhookEntry` capability for stable provider delivery IDs.
- Claim one leased inbox record per provider entry, process all sibling inputs under that lease, then complete once.
- Fail the lease when input processing fails or panics; live lease contention returns a generic 503 so the provider retries.
- Respect the HTTP envelope commit boundary: a 503 is written only before a platform response commits; committed responses are never appended or double-written.
- Treat nil, empty, and conventional zero IDs as “no durable ID” for legacy adapters.
- Persist only normalized safe failure classes through the store contract.

## Why

Webhook delivery is at least once. Deduplicating per input would incorrectly skip sibling inputs in a provider batch; guessing durable IDs from `any` can collapse unrelated legacy updates.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- Router-backed multi-input claim/complete/fail lifecycle regressions
- Pre-commit 503 and post-commit no-double-write retry regressions

## Dependencies

Stacked directly on #88 (`agent/sanitize-webhook-panic-response`). Also depends on bots-go-framework/bots-fw-store#9; the DALgo adapter is bots-go-framework/bots-fw-store-dalgo#4. Telegram #152 and the Sneat-Go adopter follow. Draft only; do not merge out of order.