### PR TITLE
Enforce host presentation policy on responders

### DIFF
--- a/botmsg/message_from_bot.go
+++ b/botmsg/message_from_bot.go
@@ -48,6 +48,14 @@ type BotMessage interface {
 	//BotEndpoint() string
 }
 
+// Presentation declares host-level presentation intent. It is optional so
+// existing messages preserve their current platform-specific behaviour.
+type Presentation struct {
+	// PersistentBottomKeyboard identifies a reply keyboard that remains visible
+	// after the message. Inline keyboards are not persistent bottom keyboards.
+	PersistentBottomKeyboard bool `json:"persistentBottomKeyboard,omitempty"`
+}
+
 // MessageFromBot keeps all the details of answer from bot to user
 //
 //goland:noinspection GoDeprecation
@@ -62,7 +70,8 @@ type MessageFromBot struct {
 	// This is a shortcut to MessageFromBot{}.BotMessage = TextMessageFromBot{text: "abc"}
 	TextMessageFromBot // TODO: This feels wrong and need to be refactored! Use BotMessage instead
 
-	BotMessage BotMessage `json:",omitempty"`
+	BotMessage   BotMessage   `json:",omitempty"`
+	Presentation Presentation `json:"presentation,omitempty"`
 
 	Analytics analytics.Message
 	//FbmAttachment      *fbmbotapi.RequestAttachment `json:",omitempty"` // deprecated

--- a/botsfw/handler.go
+++ b/botsfw/handler.go
@@ -39,6 +39,13 @@ type WebhookHandler interface {
 	//ProcessInput(input webhookInput, entry *Entry)
 }
 
+// RouterResponderProvider is an optional host adapter seam. It lets an adapter
+// supply a router-only responder while WebhookContext retains the feature
+// responder used for direct sends.
+type RouterResponderProvider interface {
+	GetRouterResponder(WebhookContext, WebhookResponder) WebhookResponder
+}
+
 type CreateWebhookContextArgs struct {
 	HttpRequest  *http.Request // TODO: Can we get rid of it? Needed for botHost.GetHTTPClient()
 	AppContext   AppContext

--- a/botsfw/presentation_policy.go
+++ b/botsfw/presentation_policy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/bots-go-framework/bots-fw/botmsg"
+	"github.com/bots-go-framework/bots-go-core/botkb"
 )
 
 type PersistentBottomKeyboardPolicy string
@@ -18,12 +19,11 @@ const (
 // PresentationPolicy is supplied by the bot host and is applied before every
 // responder send when the responder is wrapped with NewPolicyResponder.
 type PresentationPolicy struct {
-	PersistentBottomKeyboard  PersistentBottomKeyboardPolicy
-	HostMayShowBottomKeyboard bool
+	PersistentBottomKeyboard PersistentBottomKeyboardPolicy
 }
 
-func (p PresentationPolicy) Validate(m botmsg.MessageFromBot) error {
-	if !m.Presentation.PersistentBottomKeyboard {
+func (p PresentationPolicy) Validate(m botmsg.MessageFromBot, hostOwned bool) error {
+	if !hasPersistentBottomKeyboard(m) {
 		return nil
 	}
 	switch p.PersistentBottomKeyboard {
@@ -32,7 +32,7 @@ func (p PresentationPolicy) Validate(m botmsg.MessageFromBot) error {
 	case PersistentBottomKeyboardDeny:
 		return fmt.Errorf("persistent bottom keyboard denied by host presentation policy")
 	case PersistentBottomKeyboardHostOnly:
-		if p.HostMayShowBottomKeyboard {
+		if hostOwned {
 			return nil
 		}
 		return fmt.Errorf("persistent bottom keyboard is reserved for the host")
@@ -43,23 +43,49 @@ func (p PresentationPolicy) Validate(m botmsg.MessageFromBot) error {
 
 // NewPolicyResponder wraps both router-returned and direct responder sends,
 // provided the host installs the wrapper in the WebhookContext and router.
+// NewPolicyResponder creates a feature-owned responder; it cannot send a
+// host-only bottom keyboard. Hosts must use NewHostPolicyResponder explicitly.
 func NewPolicyResponder(next WebhookResponder, policy PresentationPolicy) WebhookResponder {
+	return newPolicyResponder(next, policy, false)
+}
+
+func NewHostPolicyResponder(next WebhookResponder, policy PresentationPolicy) WebhookResponder {
+	return newPolicyResponder(next, policy, true)
+}
+
+func newPolicyResponder(next WebhookResponder, policy PresentationPolicy, hostOwned bool) WebhookResponder {
 	if next == nil {
 		return nil
 	}
-	return policyResponder{next: next, policy: policy}
+	return policyResponder{next: next, policy: policy, hostOwned: hostOwned}
 }
 
 type policyResponder struct {
-	next   WebhookResponder
-	policy PresentationPolicy
+	next      WebhookResponder
+	policy    PresentationPolicy
+	hostOwned bool
 }
 
 func (r policyResponder) SendMessage(ctx context.Context, m botmsg.MessageFromBot, channel botmsg.BotAPISendMessageChannel) (OnMessageSentResponse, error) {
-	if err := r.policy.Validate(m); err != nil {
+	if err := r.policy.Validate(m, r.hostOwned); err != nil {
 		return OnMessageSentResponse{}, err
 	}
 	return r.next.SendMessage(ctx, m, channel)
+}
+
+func hasPersistentBottomKeyboard(m botmsg.MessageFromBot) bool {
+	if m.Presentation.PersistentBottomKeyboard || keyboardIsBottom(m.Keyboard) {
+		return true
+	}
+	switch message := m.BotMessage.(type) {
+	case *botmsg.TextMessageFromBot:
+		return keyboardIsBottom(message.Keyboard)
+	}
+	return false
+}
+
+func keyboardIsBottom(keyboard botkb.Keyboard) bool {
+	return keyboard != nil && keyboard.KeyboardType() == botkb.KeyboardTypeBottom
 }
 
 func (r policyResponder) DeleteMessage(ctx context.Context, messageID string) error {

--- a/botsfw/presentation_policy.go
+++ b/botsfw/presentation_policy.go
@@ -1,0 +1,67 @@
+package botsfw
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bots-go-framework/bots-fw/botmsg"
+)
+
+type PersistentBottomKeyboardPolicy string
+
+const (
+	PersistentBottomKeyboardAllow    PersistentBottomKeyboardPolicy = "allow"
+	PersistentBottomKeyboardDeny     PersistentBottomKeyboardPolicy = "deny"
+	PersistentBottomKeyboardHostOnly PersistentBottomKeyboardPolicy = "host-only"
+)
+
+// PresentationPolicy is supplied by the bot host and is applied before every
+// responder send when the responder is wrapped with NewPolicyResponder.
+type PresentationPolicy struct {
+	PersistentBottomKeyboard  PersistentBottomKeyboardPolicy
+	HostMayShowBottomKeyboard bool
+}
+
+func (p PresentationPolicy) Validate(m botmsg.MessageFromBot) error {
+	if !m.Presentation.PersistentBottomKeyboard {
+		return nil
+	}
+	switch p.PersistentBottomKeyboard {
+	case "", PersistentBottomKeyboardAllow:
+		return nil
+	case PersistentBottomKeyboardDeny:
+		return fmt.Errorf("persistent bottom keyboard denied by host presentation policy")
+	case PersistentBottomKeyboardHostOnly:
+		if p.HostMayShowBottomKeyboard {
+			return nil
+		}
+		return fmt.Errorf("persistent bottom keyboard is reserved for the host")
+	default:
+		return fmt.Errorf("unknown persistent bottom keyboard policy %q", p.PersistentBottomKeyboard)
+	}
+}
+
+// NewPolicyResponder wraps both router-returned and direct responder sends,
+// provided the host installs the wrapper in the WebhookContext and router.
+func NewPolicyResponder(next WebhookResponder, policy PresentationPolicy) WebhookResponder {
+	if next == nil {
+		return nil
+	}
+	return policyResponder{next: next, policy: policy}
+}
+
+type policyResponder struct {
+	next   WebhookResponder
+	policy PresentationPolicy
+}
+
+func (r policyResponder) SendMessage(ctx context.Context, m botmsg.MessageFromBot, channel botmsg.BotAPISendMessageChannel) (OnMessageSentResponse, error) {
+	if err := r.policy.Validate(m); err != nil {
+		return OnMessageSentResponse{}, err
+	}
+	return r.next.SendMessage(ctx, m, channel)
+}
+
+func (r policyResponder) DeleteMessage(ctx context.Context, messageID string) error {
+	return r.next.DeleteMessage(ctx, messageID)
+}

--- a/botsfw/presentation_policy.go
+++ b/botsfw/presentation_policy.go
@@ -22,6 +22,57 @@ type PresentationPolicy struct {
 	PersistentBottomKeyboard PersistentBottomKeyboardPolicy
 }
 
+// CommandResponseResponder is implemented by host-composed responders that
+// select presentation authority from the router's matched command, rather than
+// from data supplied by a feature message.
+type CommandResponseResponder interface {
+	ResponderForCommand(CommandCode) WebhookResponder
+}
+
+// NewCommandPolicyResponder makes router-return ownership depend on the command
+// codes selected by host composition. Direct sends retain feature ownership.
+func NewCommandPolicyResponder(next WebhookResponder, policy PresentationPolicy, hostCommands ...CommandCode) WebhookResponder {
+	if next == nil {
+		return nil
+	}
+	owned := make(map[CommandCode]struct{}, len(hostCommands))
+	for _, code := range hostCommands {
+		owned[code] = struct{}{}
+	}
+	return commandPolicyResponder{feature: newPolicyResponder(next, policy, false), host: next, policy: policy, hostCommands: owned}
+}
+
+type commandPolicyResponder struct {
+	feature      WebhookResponder
+	host         WebhookResponder
+	policy       PresentationPolicy
+	hostCommands map[CommandCode]struct{}
+}
+
+func (r commandPolicyResponder) SendMessage(ctx context.Context, m botmsg.MessageFromBot, channel botmsg.BotAPISendMessageChannel) (OnMessageSentResponse, error) {
+	return r.feature.SendMessage(ctx, m, channel)
+}
+
+func (r commandPolicyResponder) DeleteMessage(ctx context.Context, messageID string) error {
+	return r.feature.DeleteMessage(ctx, messageID)
+}
+
+func (r commandPolicyResponder) ResponderForCommand(code CommandCode) WebhookResponder {
+	if _, hostOwned := r.hostCommands[code]; hostOwned {
+		return newPolicyResponder(r.host, r.policy, true)
+	}
+	return r.feature
+}
+
+// ResponseResponderForCommand is called by the router after it has selected a
+// command. Only a host-composed responder can grant host presentation authority.
+func ResponseResponderForCommand(responder WebhookResponder, code CommandCode) WebhookResponder {
+	if scoped, ok := responder.(CommandResponseResponder); ok {
+		return scoped.ResponderForCommand(code)
+	}
+	return responder
+}
+
 func (p PresentationPolicy) Validate(m botmsg.MessageFromBot, hostOwned bool) error {
 	if !hasPersistentBottomKeyboard(m) {
 		return nil

--- a/botsfw/presentation_policy_test.go
+++ b/botsfw/presentation_policy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/bots-go-framework/bots-fw/botmsg"
+	"github.com/bots-go-framework/bots-go-core/botkb"
 )
 
 type presentationTestResponder struct{ sends int }
@@ -29,10 +30,39 @@ func TestPresentationPolicyResponderAppliesToDirectSends(t *testing.T) {
 
 func TestPresentationPolicyHostOnly(t *testing.T) {
 	m := botmsg.MessageFromBot{Presentation: botmsg.Presentation{PersistentBottomKeyboard: true}}
-	if err := (PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardHostOnly}).Validate(m); err == nil {
+	if err := (PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardHostOnly}).Validate(m, false); err == nil {
 		t.Fatal("expected host-only refusal")
 	}
-	if err := (PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardHostOnly, HostMayShowBottomKeyboard: true}).Validate(m); err != nil {
+	if err := (PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardHostOnly}).Validate(m, true); err != nil {
 		t.Fatalf("host keyboard: %v", err)
+	}
+}
+
+func TestHostOnlyResponderOwnershipCannotBeChosenByFeatureMessage(t *testing.T) {
+	m := botmsg.MessageFromBot{Presentation: botmsg.Presentation{PersistentBottomKeyboard: true}}
+	policy := PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardHostOnly}
+	featureNext := &presentationTestResponder{}
+	if _, err := NewPolicyResponder(featureNext, policy).SendMessage(context.Background(), m, BotAPISendMessageOverHTTPS); err == nil {
+		t.Fatal("feature-owned responder sent a host-only keyboard")
+	}
+	hostNext := &presentationTestResponder{}
+	if _, err := NewHostPolicyResponder(hostNext, policy).SendMessage(context.Background(), m, BotAPISendMessageOverHTTPS); err != nil {
+		t.Fatalf("host-owned responder: %v", err)
+	}
+	if hostNext.sends != 1 {
+		t.Fatalf("host sends = %d, want 1", hostNext.sends)
+	}
+}
+
+func TestPresentationPolicyCannotBypassWithUnmarkedBottomKeyboard(t *testing.T) {
+	next := &presentationTestResponder{}
+	responder := NewPolicyResponder(next, PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardDeny})
+	m := botmsg.MessageFromBot{}
+	m.Keyboard = botkb.NewMessageKeyboard(botkb.KeyboardTypeBottom)
+	if _, err := responder.SendMessage(context.Background(), m, BotAPISendMessageOverHTTPS); err == nil {
+		t.Fatal("unmarked bottom keyboard bypassed policy")
+	}
+	if next.sends != 0 {
+		t.Fatal("bypassed policy reached responder")
 	}
 }

--- a/botsfw/presentation_policy_test.go
+++ b/botsfw/presentation_policy_test.go
@@ -66,3 +66,21 @@ func TestPresentationPolicyCannotBypassWithUnmarkedBottomKeyboard(t *testing.T) 
 		t.Fatal("bypassed policy reached responder")
 	}
 }
+
+func TestCommandPolicyResponderUsesRouterOwnedHostCommandOnly(t *testing.T) {
+	next := &presentationTestResponder{}
+	responder := NewCommandPolicyResponder(next, PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardHostOnly}, "main_menu")
+	m := botmsg.MessageFromBot{Presentation: botmsg.Presentation{PersistentBottomKeyboard: true}}
+	if _, err := responder.SendMessage(context.Background(), m, BotAPISendMessageOverHTTPS); err == nil {
+		t.Fatal("direct feature send was granted host authority")
+	}
+	if _, err := ResponseResponderForCommand(responder, "debtus").SendMessage(context.Background(), m, BotAPISendMessageOverHTTPS); err == nil {
+		t.Fatal("embedded feature command was granted host authority")
+	}
+	if _, err := ResponseResponderForCommand(responder, "main_menu").SendMessage(context.Background(), m, BotAPISendMessageOverHTTPS); err != nil {
+		t.Fatalf("host router response: %v", err)
+	}
+	if next.sends != 1 {
+		t.Fatalf("host sends = %d, want 1", next.sends)
+	}
+}

--- a/botsfw/presentation_policy_test.go
+++ b/botsfw/presentation_policy_test.go
@@ -1,0 +1,38 @@
+package botsfw
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bots-go-framework/bots-fw/botmsg"
+)
+
+type presentationTestResponder struct{ sends int }
+
+func (r *presentationTestResponder) SendMessage(context.Context, botmsg.MessageFromBot, botmsg.BotAPISendMessageChannel) (OnMessageSentResponse, error) {
+	r.sends++
+	return OnMessageSentResponse{}, nil
+}
+func (*presentationTestResponder) DeleteMessage(context.Context, string) error { return nil }
+
+func TestPresentationPolicyResponderAppliesToDirectSends(t *testing.T) {
+	next := &presentationTestResponder{}
+	responder := NewPolicyResponder(next, PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardDeny})
+	m := botmsg.MessageFromBot{Presentation: botmsg.Presentation{PersistentBottomKeyboard: true}}
+	if _, err := responder.SendMessage(context.Background(), m, BotAPISendMessageOverHTTPS); err == nil {
+		t.Fatal("expected persistent keyboard refusal")
+	}
+	if next.sends != 0 {
+		t.Fatalf("denied send reached delegate %d times", next.sends)
+	}
+}
+
+func TestPresentationPolicyHostOnly(t *testing.T) {
+	m := botmsg.MessageFromBot{Presentation: botmsg.Presentation{PersistentBottomKeyboard: true}}
+	if err := (PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardHostOnly}).Validate(m); err == nil {
+		t.Fatal("expected host-only refusal")
+	}
+	if err := (PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardHostOnly, HostMayShowBottomKeyboard: true}).Validate(m); err != nil {
+		t.Fatalf("host keyboard: %v", err)
+	}
+}

--- a/botswebhook/driver.go
+++ b/botswebhook/driver.go
@@ -191,9 +191,13 @@ func (d webhookDriver) processWebhookInput(
 	_ = whc.ChatData()
 
 	responder := webhookHandler.GetResponder(w, whc) // TODO: Move inside webhookHandler.CreateWebhookContext()?
+	routerResponder := responder
+	if provider, ok := webhookHandler.(botsfw.RouterResponderProvider); ok {
+		routerResponder = provider.GetRouterResponder(whc, responder)
+	}
 	router := botContext.BotSettings.Profile.Router()
 
-	if err = router.Dispatch(webhookHandler, responder, whc); err != nil {
+	if err = router.Dispatch(webhookHandler, routerResponder, whc); err != nil {
 		handleError(err, "Failed to dispatch")
 		return
 	}

--- a/botswebhook/router.go
+++ b/botswebhook/router.go
@@ -851,6 +851,11 @@ func (whRouter *webhooksRouter) processCommandResponse(
 	}
 
 	c := whc.Context()
+	if matchedCommand != nil {
+		// Router-return ownership comes from the command selected by the router;
+		// feature code cannot self-assert host presentation authority in a message.
+		responder = botsfw.ResponseResponderForCommand(responder, matchedCommand.Code)
+	}
 
 	responseChannel := m.ResponseChannel
 	if responseChannel == "" {


### PR DESCRIPTION
## What changed

- Add allow, deny, and host-only policy for persistent bottom keyboards.
- Derive persistence from actual KeyboardTypeBottom payloads, including nested text messages; metadata cannot bypass the policy.
- Keep direct feature sends on a feature-owned responder.
- Add a router-only responder seam: router dispatch receives a distinct command-scoped responder after it has matched a command.
- Scope host keyboard authority to host-composed command codes, not a feature-provided message flag.

## Security invariant

Feature code receives only WebhookContext.Responder(), which is feature-owned and rejects host-only bottom keyboards. It never receives the router command capability. The driver supplies the separate router responder only to router dispatch, where actual matched command ownership selects host authority.

## Validation

- go test -race ./botsfw ./botswebhook
- go vet ./...
- direct-send refusal, actual-payload bypass, router-owned host command, and embedded command denial regressions

## Dependency

Stacked on bots-go-framework/bots-fw#89. Downstream #92 and #93 must merge after this PR.