### PR TITLE
Add fail-closed versioned conversation state

### DIFF
--- a/botswizard/conversation_state.go
+++ b/botswizard/conversation_state.go
@@ -2,6 +2,8 @@ package botswizard
 
 import (
 	"errors"
+	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -16,17 +18,37 @@ const (
 	conversationExpiresKey  = "_ce"
 	payloadPrefix           = "_cp_"
 	payloadKeysKey          = "_cp_keys"
+
+	maxConversationPayloadEntries  = 32
+	maxConversationPayloadKeyLen   = 64
+	maxConversationPayloadValueLen = 4096
 )
+
+var (
+	ErrConversationExpired          = errors.New("conversation has expired")
+	ErrConversationCorrupt          = errors.New("conversation state is corrupt")
+	ErrConversationRevisionConflict = errors.New("conversation revision conflict")
+)
+
+// FeatureID identifies the feature which owns a conversation.
+type FeatureID string
+
+// FlowID identifies a flow within a feature.
+type FlowID string
+
+// StepID identifies the current step within a flow.
+type StepID string
 
 // ConversationState is the portable, versioned state contract for a feature
 // flow. Payload is deliberately string-valued so it can be persisted through
-// legacy BotChatData wizard params without a storage migration.
+// legacy BotChatData wizard params without a storage migration. Revision is
+// observational when saved with Save; use SaveIfRevision to detect stale writes.
 type ConversationState struct {
 	Version   int
 	Revision  int64
-	Feature   string
-	Flow      string
-	Step      string
+	Feature   FeatureID
+	Flow      FlowID
+	Step      StepID
 	Payload   map[string]string
 	ExpiresAt time.Time
 }
@@ -40,32 +62,38 @@ func (v ConversationState) Expired(now time.Time) bool {
 // AwaitingReplyTo path, preserving existing command matching behaviour.
 type ConversationAdapter struct{ Now func() time.Time }
 
+func (a ConversationAdapter) clock() time.Time {
+	if a.Now != nil {
+		return a.Now()
+	}
+	return time.Now()
+}
+
+// Save writes the supplied revision as-is. It is intended for migration and
+// single-writer flows; concurrent callers must use SaveIfRevision.
 func (a ConversationAdapter) Save(st state, value ConversationState) error {
-	if strings.TrimSpace(value.Feature) == "" || strings.TrimSpace(value.Flow) == "" {
-		return errors.New("conversation feature and flow are required")
+	if err := validateConversation(value); err != nil {
+		return err
 	}
 	if value.Version <= 0 {
 		value.Version = 1
 	}
-	if value.Revision < 0 {
-		return errors.New("conversation revision cannot be negative")
-	}
-	st.SetAwaitingReplyTo(value.Flow)
+	st.SetAwaitingReplyTo(string(value.Flow))
 	st.AddWizardParam(conversationVersionKey, strconv.Itoa(value.Version))
 	st.AddWizardParam(conversationRevisionKey, strconv.FormatInt(value.Revision, 10))
-	st.AddWizardParam(conversationFeatureKey, value.Feature)
-	st.AddWizardParam(conversationFlowKey, value.Flow)
-	st.AddWizardParam(conversationStepKey, value.Step)
+	st.AddWizardParam(conversationFeatureKey, string(value.Feature))
+	st.AddWizardParam(conversationFlowKey, string(value.Flow))
+	st.AddWizardParam(conversationStepKey, string(value.Step))
 	if !value.ExpiresAt.IsZero() {
 		st.AddWizardParam(conversationExpiresKey, value.ExpiresAt.UTC().Format(time.RFC3339))
 	}
 	keys := make([]string, 0, len(value.Payload))
-	for key, payload := range value.Payload {
-		if key == "" || strings.Contains(key, ",") {
-			return errors.New("conversation payload keys must be non-empty and cannot contain commas")
-		}
-		st.AddWizardParam(payloadPrefix+key, payload)
+	for key := range value.Payload {
 		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		st.AddWizardParam(payloadPrefix+key, value.Payload[key])
 	}
 	if len(keys) > 0 {
 		st.AddWizardParam(payloadKeysKey, strings.Join(keys, ","))
@@ -73,25 +101,139 @@ func (a ConversationAdapter) Save(st state, value ConversationState) error {
 	return nil
 }
 
+// SaveIfRevision stores the next revision only when expectedRevision matches
+// the current state. An absent state has revision zero. This turns the legacy
+// parameter store into a fail-closed optimistic-concurrency boundary.
+func (a ConversationAdapter) SaveIfRevision(st state, value ConversationState, expectedRevision int64) error {
+	if expectedRevision < 0 {
+		return fmt.Errorf("%w: expected revision cannot be negative", ErrConversationRevisionConflict)
+	}
+	current, found, err := a.LoadChecked(st)
+	if err != nil && !errors.Is(err, ErrConversationExpired) {
+		return err
+	}
+	if found && current.Revision != expectedRevision {
+		return fmt.Errorf("%w: have %d, expected %d", ErrConversationRevisionConflict, current.Revision, expectedRevision)
+	}
+	if !found && expectedRevision != 0 {
+		return fmt.Errorf("%w: no state, expected %d", ErrConversationRevisionConflict, expectedRevision)
+	}
+	value.Revision = expectedRevision + 1
+	return a.Save(st, value)
+}
+
+// Load preserves the original two-value API. It fails closed for expired or
+// malformed persisted state; callers needing the reason should use LoadChecked.
 func (a ConversationAdapter) Load(st state) (ConversationState, bool) {
+	v, ok, _ := a.LoadChecked(st)
+	return v, ok
+}
+
+// LoadChecked returns a typed error for malformed or expired persisted state.
+// In either case it clears AwaitingReplyTo so a stale flow cannot be resumed.
+func (a ConversationAdapter) LoadChecked(st state) (ConversationState, bool, error) {
 	flow := st.GetWizardParam(conversationFlowKey)
 	if flow == "" { // v0 migration: preserve existing AwaitingReplyTo as flow.
 		flow = st.GetAwaitingReplyTo()
 		if flow == "" {
-			return ConversationState{}, false
+			return ConversationState{}, false, nil
 		}
-		return ConversationState{Version: 0, Flow: flow, Step: flow, Payload: map[string]string{}}, true
+		return ConversationState{Version: 0, Flow: FlowID(flow), Step: StepID(flow), Payload: map[string]string{}}, true, nil
 	}
-	v := ConversationState{Version: atoiDefault(st.GetWizardParam(conversationVersionKey), 1), Revision: int64(atoiDefault(st.GetWizardParam(conversationRevisionKey), 0)), Feature: st.GetWizardParam(conversationFeatureKey), Flow: flow, Step: st.GetWizardParam(conversationStepKey), Payload: map[string]string{}}
+	version, err := parseNonNegativeInt(st.GetWizardParam(conversationVersionKey), 1)
+	if err != nil {
+		return a.corrupt(st, err)
+	}
+	revision, err := parseNonNegativeInt64(st.GetWizardParam(conversationRevisionKey), 0)
+	if err != nil {
+		return a.corrupt(st, err)
+	}
+	v := ConversationState{Version: version, Revision: revision, Feature: FeatureID(st.GetWizardParam(conversationFeatureKey)), Flow: FlowID(flow), Step: StepID(st.GetWizardParam(conversationStepKey)), Payload: map[string]string{}}
+	if err := validateConversation(v); err != nil {
+		return a.corrupt(st, err)
+	}
 	if expires := st.GetWizardParam(conversationExpiresKey); expires != "" {
-		v.ExpiresAt, _ = time.Parse(time.RFC3339, expires)
+		v.ExpiresAt, err = time.Parse(time.RFC3339, expires)
+		if err != nil {
+			return a.corrupt(st, err)
+		}
+		if v.Expired(a.clock()) {
+			st.SetAwaitingReplyTo("")
+			return ConversationState{}, false, ErrConversationExpired
+		}
 	}
-	for _, key := range strings.Split(st.GetWizardParam(payloadKeysKey), ",") {
-		if key != "" {
+	keysText := st.GetWizardParam(payloadKeysKey)
+	if keysText != "" {
+		keys := strings.Split(keysText, ",")
+		if len(keys) > maxConversationPayloadEntries {
+			return a.corrupt(st, errors.New("too many payload entries"))
+		}
+		for _, key := range keys {
+			if err := validatePayloadEntry(key, st.GetWizardParam(payloadPrefix+key)); err != nil {
+				return a.corrupt(st, err)
+			}
+			if _, duplicate := v.Payload[key]; duplicate {
+				return a.corrupt(st, errors.New("duplicate payload key"))
+			}
 			v.Payload[key] = st.GetWizardParam(payloadPrefix + key)
 		}
 	}
-	return v, true
+	return v, true, nil
+}
+
+func (a ConversationAdapter) corrupt(st state, cause error) (ConversationState, bool, error) {
+	st.SetAwaitingReplyTo("")
+	return ConversationState{}, false, fmt.Errorf("%w: %v", ErrConversationCorrupt, cause)
+}
+
+func validateConversation(value ConversationState) error {
+	if strings.TrimSpace(string(value.Feature)) == "" || strings.TrimSpace(string(value.Flow)) == "" {
+		return errors.New("conversation feature and flow are required")
+	}
+	if value.Revision < 0 {
+		return errors.New("conversation revision cannot be negative")
+	}
+	if len(value.Payload) > maxConversationPayloadEntries {
+		return fmt.Errorf("conversation payload has more than %d entries", maxConversationPayloadEntries)
+	}
+	for key, payload := range value.Payload {
+		if err := validatePayloadEntry(key, payload); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validatePayloadEntry(key, value string) error {
+	if key == "" || len(key) > maxConversationPayloadKeyLen || strings.Contains(key, ",") {
+		return errors.New("conversation payload key is invalid")
+	}
+	if len(value) > maxConversationPayloadValueLen {
+		return errors.New("conversation payload value is too large")
+	}
+	return nil
+}
+
+func parseNonNegativeInt(raw string, defaultValue int) (int, error) {
+	if raw == "" {
+		return defaultValue, nil
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v < 0 {
+		return 0, errors.New("invalid non-negative integer")
+	}
+	return v, nil
+}
+
+func parseNonNegativeInt64(raw string, defaultValue int64) (int64, error) {
+	if raw == "" {
+		return defaultValue, nil
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || v < 0 {
+		return 0, errors.New("invalid non-negative int64")
+	}
+	return v, nil
 }
 
 func (a ConversationAdapter) Cancel(st state) { st.SetAwaitingReplyTo("") }

--- a/botswizard/conversation_state.go
+++ b/botswizard/conversation_state.go
@@ -1,0 +1,100 @@
+package botswizard
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	conversationVersionKey  = "_cv"
+	conversationRevisionKey = "_cr"
+	conversationFeatureKey  = "_cf"
+	conversationFlowKey     = "_cfl"
+	conversationStepKey     = "_cs"
+	conversationExpiresKey  = "_ce"
+	payloadPrefix           = "_cp_"
+	payloadKeysKey          = "_cp_keys"
+)
+
+// ConversationState is the portable, versioned state contract for a feature
+// flow. Payload is deliberately string-valued so it can be persisted through
+// legacy BotChatData wizard params without a storage migration.
+type ConversationState struct {
+	Version   int
+	Revision  int64
+	Feature   string
+	Flow      string
+	Step      string
+	Payload   map[string]string
+	ExpiresAt time.Time
+}
+
+func (v ConversationState) Expired(now time.Time) bool {
+	return !v.ExpiresAt.IsZero() && !now.Before(v.ExpiresAt)
+}
+
+// ConversationAdapter migrates existing AwaitingReplyTo state lazily. New
+// state is stored in namespaced wizard params; routing remains on the legacy
+// AwaitingReplyTo path, preserving existing command matching behaviour.
+type ConversationAdapter struct{ Now func() time.Time }
+
+func (a ConversationAdapter) Save(st state, value ConversationState) error {
+	if strings.TrimSpace(value.Feature) == "" || strings.TrimSpace(value.Flow) == "" {
+		return errors.New("conversation feature and flow are required")
+	}
+	if value.Version <= 0 {
+		value.Version = 1
+	}
+	if value.Revision < 0 {
+		return errors.New("conversation revision cannot be negative")
+	}
+	st.SetAwaitingReplyTo(value.Flow)
+	st.AddWizardParam(conversationVersionKey, strconv.Itoa(value.Version))
+	st.AddWizardParam(conversationRevisionKey, strconv.FormatInt(value.Revision, 10))
+	st.AddWizardParam(conversationFeatureKey, value.Feature)
+	st.AddWizardParam(conversationFlowKey, value.Flow)
+	st.AddWizardParam(conversationStepKey, value.Step)
+	if !value.ExpiresAt.IsZero() {
+		st.AddWizardParam(conversationExpiresKey, value.ExpiresAt.UTC().Format(time.RFC3339))
+	}
+	keys := make([]string, 0, len(value.Payload))
+	for key, payload := range value.Payload {
+		if key == "" || strings.Contains(key, ",") {
+			return errors.New("conversation payload keys must be non-empty and cannot contain commas")
+		}
+		st.AddWizardParam(payloadPrefix+key, payload)
+		keys = append(keys, key)
+	}
+	if len(keys) > 0 {
+		st.AddWizardParam(payloadKeysKey, strings.Join(keys, ","))
+	}
+	return nil
+}
+
+func (a ConversationAdapter) Load(st state) (ConversationState, bool) {
+	flow := st.GetWizardParam(conversationFlowKey)
+	if flow == "" { // v0 migration: preserve existing AwaitingReplyTo as flow.
+		flow = st.GetAwaitingReplyTo()
+		if flow == "" {
+			return ConversationState{}, false
+		}
+		return ConversationState{Version: 0, Flow: flow, Step: flow, Payload: map[string]string{}}, true
+	}
+	v := ConversationState{Version: atoiDefault(st.GetWizardParam(conversationVersionKey), 1), Revision: int64(atoiDefault(st.GetWizardParam(conversationRevisionKey), 0)), Feature: st.GetWizardParam(conversationFeatureKey), Flow: flow, Step: st.GetWizardParam(conversationStepKey), Payload: map[string]string{}}
+	if expires := st.GetWizardParam(conversationExpiresKey); expires != "" {
+		v.ExpiresAt, _ = time.Parse(time.RFC3339, expires)
+	}
+	for _, key := range strings.Split(st.GetWizardParam(payloadKeysKey), ",") {
+		if key != "" {
+			v.Payload[key] = st.GetWizardParam(payloadPrefix + key)
+		}
+	}
+	return v, true
+}
+
+func (a ConversationAdapter) Cancel(st state) { st.SetAwaitingReplyTo("") }
+func IsUniversalCancel(text string) bool {
+	return strings.EqualFold(strings.TrimSpace(text), "/cancel") || strings.EqualFold(strings.TrimSpace(text), "cancel")
+}

--- a/botswizard/conversation_state_test.go
+++ b/botswizard/conversation_state_test.go
@@ -1,0 +1,34 @@
+package botswizard
+
+import (
+	"testing"
+	"time"
+)
+
+func TestConversationAdapterRoundTripAndCancel(t *testing.T) {
+	st := &fakeState{}
+	a := ConversationAdapter{}
+	expires := time.Now().Add(time.Minute).UTC().Truncate(time.Second)
+	if err := a.Save(st, ConversationState{Revision: 4, Feature: "debtus", Flow: "receipt", Step: "channel", Payload: map[string]string{"id": "r1"}, ExpiresAt: expires}); err != nil {
+		t.Fatal(err)
+	}
+	got, ok := a.Load(st)
+	if !ok || got.Version != 1 || got.Revision != 4 || got.Feature != "debtus" || got.Flow != "receipt" || got.Step != "channel" || got.Payload["id"] != "r1" {
+		t.Fatalf("unexpected state: %#v, %v", got, ok)
+	}
+	a.Cancel(st)
+	if st.GetAwaitingReplyTo() != "" {
+		t.Fatal("cancel did not clear legacy state")
+	}
+}
+
+func TestConversationAdapterMigratesAwaitingReplyTo(t *testing.T) {
+	st := &fakeState{awaiting: "legacy-flow"}
+	got, ok := (ConversationAdapter{}).Load(st)
+	if !ok || got.Version != 0 || got.Flow != "legacy-flow" {
+		t.Fatalf("unexpected migration: %#v, %v", got, ok)
+	}
+	if !IsUniversalCancel(" /cancel ") {
+		t.Fatal("cancel command not recognized")
+	}
+}

--- a/botswizard/conversation_state_test.go
+++ b/botswizard/conversation_state_test.go
@@ -1,14 +1,17 @@
 package botswizard
 
 import (
+	"errors"
+	"strings"
 	"testing"
 	"time"
 )
 
 func TestConversationAdapterRoundTripAndCancel(t *testing.T) {
 	st := &fakeState{}
-	a := ConversationAdapter{}
-	expires := time.Now().Add(time.Minute).UTC().Truncate(time.Second)
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	a := ConversationAdapter{Now: func() time.Time { return now }}
+	expires := now.Add(time.Minute)
 	if err := a.Save(st, ConversationState{Revision: 4, Feature: "debtus", Flow: "receipt", Step: "channel", Payload: map[string]string{"id": "r1"}, ExpiresAt: expires}); err != nil {
 		t.Fatal(err)
 	}
@@ -19,6 +22,57 @@ func TestConversationAdapterRoundTripAndCancel(t *testing.T) {
 	a.Cancel(st)
 	if st.GetAwaitingReplyTo() != "" {
 		t.Fatal("cancel did not clear legacy state")
+	}
+}
+
+func TestConversationAdapterExpiresAtClockBoundaryAndClearsState(t *testing.T) {
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	a := ConversationAdapter{Now: func() time.Time { return now }}
+	st := &fakeState{}
+	if err := a.Save(st, ConversationState{Feature: "debtus", Flow: "receipt", ExpiresAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	_, ok, err := a.LoadChecked(st)
+	if ok || !errors.Is(err, ErrConversationExpired) {
+		t.Fatalf("load = ok:%v err:%v, want expired", ok, err)
+	}
+	if st.GetAwaitingReplyTo() != "" {
+		t.Fatal("expired conversation was not cleared")
+	}
+}
+
+func TestConversationAdapterRejectsCorruptAndOversizedState(t *testing.T) {
+	st := &fakeState{awaiting: "receipt", params: map[string]string{
+		conversationFlowKey:     "receipt",
+		conversationFeatureKey:  "debtus",
+		conversationRevisionKey: "not-a-number",
+	}}
+	_, ok, err := (ConversationAdapter{}).LoadChecked(st)
+	if ok || !errors.Is(err, ErrConversationCorrupt) {
+		t.Fatalf("load = ok:%v err:%v, want corrupt", ok, err)
+	}
+	if st.GetAwaitingReplyTo() != "" {
+		t.Fatal("corrupt conversation was not cleared")
+	}
+	big := strings.Repeat("x", maxConversationPayloadValueLen+1)
+	if err := (ConversationAdapter{}).Save(&fakeState{}, ConversationState{Feature: "debtus", Flow: "receipt", Payload: map[string]string{"x": big}}); err == nil {
+		t.Fatal("oversized payload was accepted")
+	}
+}
+
+func TestConversationAdapterSaveIfRevisionRejectsStaleWriter(t *testing.T) {
+	st := &fakeState{}
+	a := ConversationAdapter{}
+	value := ConversationState{Feature: "debtus", Flow: "receipt"}
+	if err := a.SaveIfRevision(st, value, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.SaveIfRevision(st, value, 0); !errors.Is(err, ErrConversationRevisionConflict) {
+		t.Fatalf("stale save error = %v", err)
+	}
+	got, ok := a.Load(st)
+	if !ok || got.Revision != 1 {
+		t.Fatalf("revision = %#v, %v", got, ok)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Add typed feature, flow, and step identifiers plus versioned conversation state.
- Migrate legacy AwaitingReplyTo lazily while retaining compatibility.
- Use an injected clock and fail closed for expired or corrupt state, clearing the legacy route.
- Sort and bound persisted payloads; expose SaveIfRevision for explicit stale-write detection.

## Security invariant

Expired or malformed conversation state cannot resume a feature flow. Revision checks are explicit; plain Save is documented as observational rather than optimistic concurrency.

## Validation

- go test -race ./botswizard
- go vet ./...
- expiry boundary, corrupt-state, oversized payload, deterministic serialization, and stale-write tests

## Dependency

Stacked on bots-go-framework/bots-fw#91; merge after #91.