### PR TITLE
Replay feature mounts under host policy

### DIFF
--- a/botsfw/feature_scenario.go
+++ b/botsfw/feature_scenario.go
@@ -1,0 +1,69 @@
+package botsfw
+
+import (
+	"fmt"
+
+	"github.com/bots-go-framework/bots-fw/botmsg"
+)
+
+// FeatureScenario is a deterministic host-level acceptance harness. Feature
+// adapters provide the plan instead of invoking network responders, so the
+// same assertions cover dedicated and embedded mounting modes.
+type FeatureScenario struct {
+	Mount       FeatureMount
+	Messages    []botmsg.MessageFromBot
+	Navigation  []NavigatorID
+	SideEffects []string
+}
+
+type FeatureScenarioExpectation struct {
+	Mode        FeatureMountMode
+	Messages    int
+	Navigation  []NavigatorID
+	SideEffects []string
+	Policy      PresentationPolicy
+}
+
+func AssertFeatureScenario(s FeatureScenario, want FeatureScenarioExpectation) error {
+	if s.Mount.Mode != want.Mode {
+		return fmt.Errorf("mount mode = %q, want %q", s.Mount.Mode, want.Mode)
+	}
+	if len(s.Messages) != want.Messages {
+		return fmt.Errorf("messages = %d, want %d", len(s.Messages), want.Messages)
+	}
+	if !sameNavigators(s.Navigation, want.Navigation) {
+		return fmt.Errorf("navigation = %v, want %v", s.Navigation, want.Navigation)
+	}
+	if !sameStrings(s.SideEffects, want.SideEffects) {
+		return fmt.Errorf("side effects = %v, want %v", s.SideEffects, want.SideEffects)
+	}
+	for _, message := range s.Messages {
+		if err := want.Policy.Validate(message); err != nil {
+			return fmt.Errorf("message plan violates presentation policy: %w", err)
+		}
+	}
+	return nil
+}
+
+func sameNavigators(a, b []NavigatorID) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/botsfw/feature_scenario.go
+++ b/botsfw/feature_scenario.go
@@ -6,19 +6,93 @@ import (
 	"github.com/bots-go-framework/bots-fw/botmsg"
 )
 
-// FeatureScenario is a deterministic host-level acceptance harness. Feature
-// adapters provide the plan instead of invoking network responders, so the
-// same assertions cover dedicated and embedded mounting modes.
+// ScenarioMessagePath identifies the transport path used to present a
+// message. Feature-returned messages and direct sends are feature-owned;
+// HostSend is available only to the host fixture for its own UI.
+type ScenarioMessagePath string
+
+const (
+	ScenarioRouterReturn ScenarioMessagePath = "router-return"
+	ScenarioDirectSend   ScenarioMessagePath = "direct-send"
+	ScenarioHostSend     ScenarioMessagePath = "host-send"
+)
+
+type ScenarioMessage struct {
+	Path    ScenarioMessagePath
+	Message botmsg.MessageFromBot
+}
+
+// FeatureScenario is an executed, deterministic host-level acceptance trace.
+// It records both router-return and direct-send paths so presentation policy
+// cannot be bypassed by choosing a different response path.
 type FeatureScenario struct {
 	Mount       FeatureMount
-	Messages    []botmsg.MessageFromBot
+	Messages    []ScenarioMessage
 	Navigation  []NavigatorID
 	SideEffects []string
+}
+
+// FeatureScenarioFlow is supplied by a feature adapter fixture. The harness
+// executes it under a concrete mount and validates every emitted message.
+type FeatureScenarioFlow func(*FeatureScenarioContext) error
+
+// FeatureScenarioContext provides the only output paths a replay fixture may
+// use. SendHost models host UI (Home, keyboard removal, or inline controls),
+// while feature paths are always treated as non-host-owned.
+type FeatureScenarioContext struct {
+	scenario *FeatureScenario
+	policy   PresentationPolicy
+}
+
+func (c *FeatureScenarioContext) ReturnFromRouter(message botmsg.MessageFromBot) error {
+	return c.addMessage(ScenarioRouterReturn, message, false)
+}
+
+func (c *FeatureScenarioContext) SendDirect(message botmsg.MessageFromBot) error {
+	return c.addMessage(ScenarioDirectSend, message, false)
+}
+
+func (c *FeatureScenarioContext) SendHost(message botmsg.MessageFromBot) error {
+	return c.addMessage(ScenarioHostSend, message, true)
+}
+
+func (c *FeatureScenarioContext) Navigate(to NavigatorID) {
+	c.scenario.Navigation = append(c.scenario.Navigation, to)
+}
+
+func (c *FeatureScenarioContext) SideEffect(effect string) {
+	c.scenario.SideEffects = append(c.scenario.SideEffects, effect)
+}
+
+func (c *FeatureScenarioContext) addMessage(path ScenarioMessagePath, message botmsg.MessageFromBot, hostOwned bool) error {
+	if err := c.policy.Validate(message, hostOwned); err != nil {
+		return fmt.Errorf("%s message violates presentation policy: %w", path, err)
+	}
+	c.scenario.Messages = append(c.scenario.Messages, ScenarioMessage{Path: path, Message: message})
+	return nil
+}
+
+// ReplayFeatureScenario validates a mount and executes the supplied flow under
+// that mount context. It is intentionally transport-free, but exercises the
+// same router-return and direct-send ownership boundaries as a host adapter.
+func ReplayFeatureScenario(mount FeatureMount, policy PresentationPolicy, flow FeatureScenarioFlow) (FeatureScenario, error) {
+	if _, err := NewFeatureRegistry(mount); err != nil {
+		return FeatureScenario{}, err
+	}
+	scenario := FeatureScenario{Mount: mount}
+	if flow == nil {
+		return scenario, nil
+	}
+	if err := flow(&FeatureScenarioContext{scenario: &scenario, policy: policy}); err != nil {
+		return FeatureScenario{}, err
+	}
+	return scenario, nil
 }
 
 type FeatureScenarioExpectation struct {
 	Mode        FeatureMountMode
 	Messages    int
+	Paths       []ScenarioMessagePath
 	Navigation  []NavigatorID
 	SideEffects []string
 	Policy      PresentationPolicy
@@ -31,6 +105,16 @@ func AssertFeatureScenario(s FeatureScenario, want FeatureScenarioExpectation) e
 	if len(s.Messages) != want.Messages {
 		return fmt.Errorf("messages = %d, want %d", len(s.Messages), want.Messages)
 	}
+	if len(want.Paths) > 0 {
+		if len(s.Messages) != len(want.Paths) {
+			return fmt.Errorf("message paths = %d, want %d", len(s.Messages), len(want.Paths))
+		}
+		for i, message := range s.Messages {
+			if message.Path != want.Paths[i] {
+				return fmt.Errorf("message %d path = %q, want %q", i, message.Path, want.Paths[i])
+			}
+		}
+	}
 	if !sameNavigators(s.Navigation, want.Navigation) {
 		return fmt.Errorf("navigation = %v, want %v", s.Navigation, want.Navigation)
 	}
@@ -38,7 +122,7 @@ func AssertFeatureScenario(s FeatureScenario, want FeatureScenarioExpectation) e
 		return fmt.Errorf("side effects = %v, want %v", s.SideEffects, want.SideEffects)
 	}
 	for _, message := range s.Messages {
-		if err := want.Policy.Validate(message); err != nil {
+		if err := want.Policy.Validate(message.Message, message.Path == ScenarioHostSend); err != nil {
 			return fmt.Errorf("message plan violates presentation policy: %w", err)
 		}
 	}

--- a/botsfw/feature_scenario_test.go
+++ b/botsfw/feature_scenario_test.go
@@ -1,0 +1,37 @@
+package botsfw
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bots-go-framework/bots-fw/botmsg"
+)
+
+func TestFeatureScenarioHarnessDedicatedAndEmbedded(t *testing.T) {
+	for _, scenario := range []struct {
+		name       string
+		mode       FeatureMountMode
+		navigation []NavigatorID
+	}{
+		{"dedicated", FeatureMountDedicated, []NavigatorID{"debtus"}},
+		{"embedded", FeatureMountEmbedded, []NavigatorID{"home", "debtus"}},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			mount := FeatureMount{ID: "debtus", Mode: scenario.mode}
+			if scenario.mode == FeatureMountEmbedded {
+				mount.Namespace = "debtus"
+			}
+			err := AssertFeatureScenario(FeatureScenario{Mount: mount, Messages: []botmsg.MessageFromBot{{Presentation: botmsg.Presentation{PersistentBottomKeyboard: true}}}, Navigation: scenario.navigation, SideEffects: []string{"show-space"}}, FeatureScenarioExpectation{Mode: scenario.mode, Messages: 1, Navigation: scenario.navigation, SideEffects: []string{"show-space"}, Policy: PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardHostOnly, HostMayShowBottomKeyboard: true}})
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestFeatureScenarioHarnessRejectsKeyboardPolicyViolation(t *testing.T) {
+	err := AssertFeatureScenario(FeatureScenario{Mount: FeatureMount{ID: "d", Mode: FeatureMountDedicated}, Messages: []botmsg.MessageFromBot{{Presentation: botmsg.Presentation{PersistentBottomKeyboard: true}}}}, FeatureScenarioExpectation{Mode: FeatureMountDedicated, Messages: 1, Policy: PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardDeny}})
+	if err == nil || !strings.Contains(err.Error(), "persistent") {
+		t.Fatalf("expected policy violation, got %v", err)
+	}
+}

--- a/botsfw/feature_scenario_test.go
+++ b/botsfw/feature_scenario_test.go
@@ -5,23 +5,44 @@ import (
 	"testing"
 
 	"github.com/bots-go-framework/bots-fw/botmsg"
+	"github.com/bots-go-framework/bots-go-core/botkb"
 )
 
-func TestFeatureScenarioHarnessDedicatedAndEmbedded(t *testing.T) {
-	for _, scenario := range []struct {
+func TestFeatureScenarioReplayDedicatedAndEmbedded(t *testing.T) {
+	debtusFlow := func(ctx *FeatureScenarioContext) error {
+		if err := ctx.ReturnFromRouter(botmsg.MessageFromBot{}); err != nil {
+			return err
+		}
+		if err := ctx.SendDirect(botmsg.MessageFromBot{}); err != nil {
+			return err
+		}
+		ctx.SideEffect("show-space")
+		return nil
+	}
+	for _, test := range []struct {
 		name       string
-		mode       FeatureMountMode
+		mount      FeatureMount
 		navigation []NavigatorID
 	}{
-		{"dedicated", FeatureMountDedicated, []NavigatorID{"debtus"}},
-		{"embedded", FeatureMountEmbedded, []NavigatorID{"home", "debtus"}},
+		{"dedicated", FeatureMount{ID: "debtus", Mode: FeatureMountDedicated}, []NavigatorID{"debtus"}},
+		{"embedded", FeatureMount{ID: "debtus-embedded", Mode: FeatureMountEmbedded, Namespace: "debtus"}, []NavigatorID{"home", "debtus"}},
 	} {
-		t.Run(scenario.name, func(t *testing.T) {
-			mount := FeatureMount{ID: "debtus", Mode: scenario.mode}
-			if scenario.mode == FeatureMountEmbedded {
-				mount.Namespace = "debtus"
+		t.Run(test.name, func(t *testing.T) {
+			scenario, err := ReplayFeatureScenario(test.mount, PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardHostOnly}, func(ctx *FeatureScenarioContext) error {
+				ctx.scenario.Navigation = append(ctx.scenario.Navigation, test.navigation...)
+				return debtusFlow(ctx)
+			})
+			if err != nil {
+				t.Fatal(err)
 			}
-			err := AssertFeatureScenario(FeatureScenario{Mount: mount, Messages: []botmsg.MessageFromBot{{Presentation: botmsg.Presentation{PersistentBottomKeyboard: true}}}, Navigation: scenario.navigation, SideEffects: []string{"show-space"}}, FeatureScenarioExpectation{Mode: scenario.mode, Messages: 1, Navigation: scenario.navigation, SideEffects: []string{"show-space"}, Policy: PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardHostOnly, HostMayShowBottomKeyboard: true}})
+			err = AssertFeatureScenario(scenario, FeatureScenarioExpectation{
+				Mode:        test.mount.Mode,
+				Messages:    2,
+				Paths:       []ScenarioMessagePath{ScenarioRouterReturn, ScenarioDirectSend},
+				Navigation:  test.navigation,
+				SideEffects: []string{"show-space"},
+				Policy:      PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardHostOnly},
+			})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -29,9 +50,41 @@ func TestFeatureScenarioHarnessDedicatedAndEmbedded(t *testing.T) {
 	}
 }
 
-func TestFeatureScenarioHarnessRejectsKeyboardPolicyViolation(t *testing.T) {
-	err := AssertFeatureScenario(FeatureScenario{Mount: FeatureMount{ID: "d", Mode: FeatureMountDedicated}, Messages: []botmsg.MessageFromBot{{Presentation: botmsg.Presentation{PersistentBottomKeyboard: true}}}}, FeatureScenarioExpectation{Mode: FeatureMountDedicated, Messages: 1, Policy: PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardDeny}})
-	if err == nil || !strings.Contains(err.Error(), "persistent") {
-		t.Fatalf("expected policy violation, got %v", err)
+func TestFeatureScenarioReplayRejectsEmbeddedFeatureBottomKeyboard(t *testing.T) {
+	_, err := ReplayFeatureScenario(
+		FeatureMount{ID: "debtus-embedded", Mode: FeatureMountEmbedded, Namespace: "debtus"},
+		PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardHostOnly},
+		func(ctx *FeatureScenarioContext) error {
+			message := botmsg.MessageFromBot{}
+			message.Keyboard = botkb.NewMessageKeyboard(botkb.KeyboardTypeBottom)
+			return ctx.ReturnFromRouter(message)
+		},
+	)
+	if err == nil || !strings.Contains(err.Error(), "reserved for the host") {
+		t.Fatalf("expected embedded feature keyboard rejection, got %v", err)
+	}
+}
+
+func TestFeatureScenarioReplayAllowsHostHomeRemoveAndInlineMessages(t *testing.T) {
+	scenario, err := ReplayFeatureScenario(FeatureMount{ID: "debtus", Mode: FeatureMountDedicated}, PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardHostOnly}, func(ctx *FeatureScenarioContext) error {
+		for _, kind := range []botkb.KeyboardType{botkb.KeyboardTypeBottom, botkb.KeyboardTypeHide, botkb.KeyboardTypeInline} {
+			message := botmsg.MessageFromBot{}
+			message.Keyboard = botkb.NewMessageKeyboard(kind)
+			if err := ctx.SendHost(message); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := AssertFeatureScenario(scenario, FeatureScenarioExpectation{
+		Mode:     FeatureMountDedicated,
+		Messages: 3,
+		Paths:    []ScenarioMessagePath{ScenarioHostSend, ScenarioHostSend, ScenarioHostSend},
+		Policy:   PresentationPolicy{PersistentBottomKeyboard: PersistentBottomKeyboardHostOnly},
+	}); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## What changed

- Add an executable dedicated-versus-embedded feature scenario harness.
- Replay router-return, direct-send, and host-send output paths instead of asserting prebuilt slices only.
- Verify message plan, navigation, side effects, and presentation policy from the actual mount context.

## Security invariant

Embedded Debtus router and direct paths cannot emit a persistent bottom keyboard. Host Home, keyboard-hide/remove, and inline UI are permitted only through the host path.

## Validation

- go test -race ./botsfw
- go vet ./...
- dedicated and embedded replay fixtures plus bottom-keyboard denial and host Home/hide/inline regressions

## Dependency

Stacked on bots-go-framework/bots-fw#92, which is stacked on #91 and #89. Merge in stack order.