### PR TITLE
fix(deps): pin bots-fw-store v0.14.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.25
 //replace github.com/strongo/i18n => ../../strongo/i18n
 //replace github.com/bots-go-framework/bots-go-core => ../bots-go-core
 require (
-	github.com/bots-go-framework/bots-fw-store v0.14.1-0.20260725165959-023758cc8659
+	github.com/bots-go-framework/bots-fw-store v0.14.1
 	github.com/bots-go-framework/bots-go-core v0.2.5
 	github.com/felixge/httpsnoop v1.1.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bots-go-framework/bots-fw-store v0.14.1-0.20260725165959-023758cc8659 h1:ZF953xBKI5eSMzA+jENLnv/jXn33SXvGlpL9eA6sxqI=
-github.com/bots-go-framework/bots-fw-store v0.14.1-0.20260725165959-023758cc8659/go.mod h1:0yS6Pg516jHIrIInv+kvWRWxXNGGqR4tlvRua8GfT20=
+github.com/bots-go-framework/bots-fw-store v0.14.1 h1:uo+jEI16A/7oiZzxPdom0q1fXXmc/xOsRYypu3CkHGM=
+github.com/bots-go-framework/bots-fw-store v0.14.1/go.mod h1:0yS6Pg516jHIrIInv+kvWRWxXNGGqR4tlvRua8GfT20=
 github.com/bots-go-framework/bots-go-core v0.2.5 h1:Uv9zb23yHJY/GnfEF6ocucAmfS12pwFHiig29ZoSqME=
 github.com/bots-go-framework/bots-go-core v0.2.5/go.mod h1:O/J3Q4HhTpbsbCL87Zhlf1BPtvfVp9UcfBWsc8D8ghw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
Replaces the temporary pseudo-version with the immutable stable `v0.14.1` release tag.\n\nValidated with `GOWORK=off go test ./...` and `GOWORK=off go vet ./...`.\n\nSupersedes Renovate #94, which targeted a raw commit hash rather than the published stable tag.