### PR TITLE
Add configurable published command ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,39 @@ needed.
 		)
 	}
 
+### Published command ordering
+
+Bot profiles can preserve their declared command order, sort all commands
+alphabetically, or pin important commands above an alphabetical remainder:
+
+```go
+translations := botsfw.BotTranslations{
+	Commands: []botsfw.BotCommand{
+		{Command: "find", Description: "Find something"},
+		{Command: "sports", Description: "Open sports"},
+		{Command: "main", Description: "Open the main menu"},
+	},
+}
+profile := botsfw.NewBotProfile(
+	"profile_id",
+	router,
+	newBotChatData,
+	newBotUserData,
+	defaultLocale,
+	supportedLocales,
+	translations,
+	botsfw.WithPublishedCommandOrder(
+		botsfw.BotCommandOrderPinnedThenAlphabetical,
+		"main",
+		"sports",
+	),
+)
+```
+
+Pinned command codes are required configuration: every pinned code must occur
+exactly once in `Commands`. Invalid profile configuration fails fast instead of
+silently publishing a missing or duplicated command.
+
 ## 🤖 Sample bots built with Strongo Bots Framework
 
 The best way to learn is to see examples of usage. Here is few:

--- a/botsfw/bot_command_order_test.go
+++ b/botsfw/bot_command_order_test.go
@@ -1,0 +1,114 @@
+package botsfw
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrderBotCommands(t *testing.T) {
+	commands := []BotCommand{
+		{Command: "watch", Description: "Watch"},
+		{Command: "sports", Description: "Sports"},
+		{Command: "find", Description: "Find"},
+		{Command: "main", Description: "Main"},
+		{Command: "games", Description: "Games"},
+	}
+
+	t.Run("declared", func(t *testing.T) {
+		ordered, err := OrderBotCommands(commands, BotCommandOrderDeclared)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"watch", "sports", "find", "main", "games"}, botCommandCodes(ordered))
+		ordered[0].Command = "changed"
+		assert.Equal(t, "watch", commands[0].Command, "OrderBotCommands must return a copy")
+	})
+
+	t.Run("alphabetical", func(t *testing.T) {
+		ordered, err := OrderBotCommands(commands, BotCommandOrderAlphabetical)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"find", "games", "main", "sports", "watch"}, botCommandCodes(ordered))
+	})
+
+	t.Run("pinned_then_alphabetical", func(t *testing.T) {
+		ordered, err := OrderBotCommands(
+			commands,
+			BotCommandOrderPinnedThenAlphabetical,
+			"main",
+			"sports",
+		)
+
+		require.NoError(t, err)
+		assert.Equal(t, []string{"main", "sports", "find", "games", "watch"}, botCommandCodes(ordered))
+	})
+}
+
+func TestOrderBotCommandsRejectsInvalidConfiguration(t *testing.T) {
+	commands := []BotCommand{{Command: "main", Description: "Main"}}
+
+	tests := []struct {
+		name         string
+		order        BotCommandOrder
+		pinned       []string
+		extraCommand []BotCommand
+		errorText    string
+	}{
+		{
+			name:      "pins_with_declared_order",
+			pinned:    []string{"main"},
+			errorText: "pinned commands require pinned_then_alphabetical command order",
+		},
+		{
+			name:      "pins_with_alphabetical_order",
+			order:     BotCommandOrderAlphabetical,
+			pinned:    []string{"main"},
+			errorText: "pinned commands require pinned_then_alphabetical command order",
+		},
+		{
+			name:      "unknown_order",
+			order:     BotCommandOrder("popular"),
+			errorText: `unknown bot command order: "popular"`,
+		},
+		{
+			name:      "missing_pin",
+			order:     BotCommandOrderPinnedThenAlphabetical,
+			pinned:    []string{"sports"},
+			errorText: `pinned published command "sports" is missing`,
+		},
+		{
+			name:      "duplicate_pin",
+			order:     BotCommandOrderPinnedThenAlphabetical,
+			pinned:    []string{"main", "main"},
+			errorText: `published command "main" is pinned more than once`,
+		},
+		{
+			name:         "duplicated_pinned_command",
+			order:        BotCommandOrderPinnedThenAlphabetical,
+			pinned:       []string{"main"},
+			extraCommand: []BotCommand{{Command: "main", Description: "Main again"}},
+			errorText:    `pinned published command "main" is duplicated`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := OrderBotCommands(
+				append(commands, test.extraCommand...),
+				test.order,
+				test.pinned...,
+			)
+
+			require.EqualError(t, err, test.errorText)
+		})
+	}
+}
+
+func botCommandCodes(commands []BotCommand) []string {
+	result := make([]string, len(commands))
+	for i, command := range commands {
+		result[i] = command.Command
+	}
+	return result
+}

--- a/botsfw/bot_profile.go
+++ b/botsfw/bot_profile.go
@@ -2,15 +2,105 @@ package botsfw
 
 import (
 	"errors"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
 	"github.com/bots-go-framework/bots-fw-store/botsfwmodels"
 	"github.com/strongo/i18n"
-	"strings"
+)
+
+type BotCommandOrder string
+
+const (
+	// BotCommandOrderDeclared preserves the order in BotTranslations.Commands.
+	BotCommandOrderDeclared BotCommandOrder = ""
+	// BotCommandOrderAlphabetical orders all published commands by command code.
+	BotCommandOrderAlphabetical BotCommandOrder = "alphabetical"
+	// BotCommandOrderPinnedThenAlphabetical puts explicitly pinned commands
+	// first and orders every remaining command by command code.
+	BotCommandOrderPinnedThenAlphabetical BotCommandOrder = "pinned_then_alphabetical"
 )
 
 type BotTranslations struct {
 	Description      string
 	ShortDescription string
 	Commands         []BotCommand
+}
+
+// OrderBotCommands returns a copy arranged according to order.
+// pinnedCommands is only valid with BotCommandOrderPinnedThenAlphabetical,
+// and the supplied pin order is preserved.
+func OrderBotCommands(
+	commands []BotCommand,
+	order BotCommandOrder,
+	pinnedCommands ...string,
+) ([]BotCommand, error) {
+	orderedCommands := slices.Clone(commands)
+	switch order {
+	case BotCommandOrderDeclared:
+		if len(pinnedCommands) > 0 {
+			return nil, errors.New("pinned commands require pinned_then_alphabetical command order")
+		}
+		return orderedCommands, nil
+
+	case BotCommandOrderAlphabetical:
+		if len(pinnedCommands) > 0 {
+			return nil, errors.New("pinned commands require pinned_then_alphabetical command order")
+		}
+		sort.SliceStable(orderedCommands, func(i, j int) bool {
+			return orderedCommands[i].Command < orderedCommands[j].Command
+		})
+		return orderedCommands, nil
+
+	case BotCommandOrderPinnedThenAlphabetical:
+		pinnedOrder, err := pinnedCommandOrder(commands, pinnedCommands)
+		if err != nil {
+			return nil, err
+		}
+		sort.SliceStable(orderedCommands, func(i, j int) bool {
+			iPinnedOrder, iIsPinned := pinnedOrder[orderedCommands[i].Command]
+			jPinnedOrder, jIsPinned := pinnedOrder[orderedCommands[j].Command]
+			switch {
+			case iIsPinned && jIsPinned:
+				return iPinnedOrder < jPinnedOrder
+			case iIsPinned:
+				return true
+			case jIsPinned:
+				return false
+			default:
+				return orderedCommands[i].Command < orderedCommands[j].Command
+			}
+		})
+		return orderedCommands, nil
+
+	default:
+		return nil, fmt.Errorf("unknown bot command order: %q", order)
+	}
+}
+
+func pinnedCommandOrder(commands []BotCommand, pinnedCommands []string) (map[string]int, error) {
+	commandCounts := make(map[string]int, len(commands))
+	for _, command := range commands {
+		commandCounts[command.Command]++
+	}
+
+	pinnedOrder := make(map[string]int, len(pinnedCommands))
+	for i, commandCode := range pinnedCommands {
+		if _, ok := pinnedOrder[commandCode]; ok {
+			return nil, fmt.Errorf("published command %q is pinned more than once", commandCode)
+		}
+		switch commandCounts[commandCode] {
+		case 0:
+			return nil, fmt.Errorf("pinned published command %q is missing", commandCode)
+		case 1:
+			pinnedOrder[commandCode] = i
+		default:
+			return nil, fmt.Errorf("pinned published command %q is duplicated", commandCode)
+		}
+	}
+	return pinnedOrder, nil
 }
 
 type BotCommand struct {
@@ -42,6 +132,25 @@ type BotProfile interface {
 	NewBotChatData() botsfwmodels.BotChatData
 	NewPlatformUserData() botsfwmodels.PlatformUserData
 	GetTranslations() BotTranslations
+}
+
+type BotProfileOption func(*botProfileConfig)
+
+type botProfileConfig struct {
+	commandOrder   BotCommandOrder
+	pinnedCommands []string
+}
+
+// WithPublishedCommandOrder configures how a profile exposes its published
+// commands. Pinned command codes are required to occur exactly once.
+func WithPublishedCommandOrder(
+	order BotCommandOrder,
+	pinnedCommands ...string,
+) BotProfileOption {
+	return func(config *botProfileConfig) {
+		config.commandOrder = order
+		config.pinnedCommands = slices.Clone(pinnedCommands)
+	}
 }
 
 var _ BotProfile = (*botProfile)(nil)
@@ -92,6 +201,7 @@ func NewBotProfile(
 	defaultLocale i18n.Locale,
 	supportedLocales []i18n.Locale,
 	translations BotTranslations,
+	options ...BotProfileOption,
 ) BotProfile {
 	if strings.TrimSpace(id) == "" {
 		panic("missing required parameter: id")
@@ -112,6 +222,22 @@ func NewBotProfile(
 	if !defaultLocaleInSupportedLocales {
 		supportedLocales = append(supportedLocales, defaultLocale)
 	}
+	var config botProfileConfig
+	for i, option := range options {
+		if option == nil {
+			panic(fmt.Sprintf("nil bot profile option at index %d", i))
+		}
+		option(&config)
+	}
+	orderedCommands, err := OrderBotCommands(
+		translations.Commands,
+		config.commandOrder,
+		config.pinnedCommands...,
+	)
+	if err != nil {
+		panic(fmt.Sprintf("invalid published command order: %v", err))
+	}
+	translations.Commands = orderedCommands
 	return &botProfile{
 		id:               id,
 		router:           router,

--- a/botsfw/bot_profile_test.go
+++ b/botsfw/bot_profile_test.go
@@ -107,6 +107,52 @@ func TestNewBotProfile(t *testing.T) {
 		assert.Equal(t, translations, profile.GetTranslations())
 	})
 
+	t.Run("applies_command_order", func(t *testing.T) {
+		translations := BotTranslations{
+			Commands: []BotCommand{
+				{Command: "watch", Description: "Watch"},
+				{Command: "sports", Description: "Sports"},
+				{Command: "main", Description: "Main"},
+			},
+		}
+
+		profile := NewBotProfile(
+			"ordered_bot",
+			nil,
+			newBotChatData,
+			newBotUserData,
+			locale,
+			nil,
+			translations,
+			WithPublishedCommandOrder(BotCommandOrderPinnedThenAlphabetical, "main"),
+		)
+
+		assert.Equal(t, []string{"main", "sports", "watch"}, botCommandCodes(profile.GetTranslations().Commands))
+	})
+
+	t.Run("panics_on_invalid_command_order", func(t *testing.T) {
+		translations := BotTranslations{
+			Commands: []BotCommand{{Command: "main", Description: "Main"}},
+		}
+
+		assert.PanicsWithValue(
+			t,
+			"invalid published command order: pinned commands require pinned_then_alphabetical command order",
+			func() {
+				NewBotProfile(
+					"invalid_order_bot",
+					nil,
+					newBotChatData,
+					newBotUserData,
+					locale,
+					nil,
+					translations,
+					WithPublishedCommandOrder(BotCommandOrderDeclared, "main"),
+				)
+			},
+		)
+	})
+
 	t.Run("default_locale_added_to_supported", func(t *testing.T) {
 		profile := NewBotProfile("bot1", nil, newBotChatData, newBotUserData, locale, nil, BotTranslations{})
 		supported := profile.SupportedLocales()


### PR DESCRIPTION
## What changed

- Adds a public bot-profile ordering policy with declared, alphabetical, and pinned-then-alphabetical modes.
- Adds `WithPublishedCommandOrder` as a source-compatible `NewBotProfile` option.
- Requires every pinned command to exist exactly once; invalid static profile configuration fails fast.
- Keeps ordering invisible to users and returns ordered command metadata to existing consumers.
- Documents the feature with an example.

## Why

Bots with large command catalogues need stable discovery without forcing every profile to hand-sort its metadata. Profiles can now pin a small set of primary commands while keeping the remainder predictable.

## Validation

- `go test ./...`
- `go vet ./...`
- `git diff --check`
